### PR TITLE
fix(skills): close planning-flow gaps #124-#131

### DIFF
--- a/docs/running-autonomously.md
+++ b/docs/running-autonomously.md
@@ -1,0 +1,53 @@
+# Running Rihal Autonomously
+
+Most Rihal skills (create-prd, create-milestone, create-epics-and-stories, sprint-planning) use **step-file architecture**: they halt at every menu and wait for user input. This is the default and it is deliberate — the product of these skills is only as good as the discovery that produces them.
+
+There are exactly two sanctioned ways to run these skills without halting at menus. Any other "autonomous mode" an agent declares is invented and should be rejected (see issue #124).
+
+## Sanctioned Path 1 — Project-wide: `mode: yolo`
+
+Edit `.rihal/config.yaml`:
+
+```yaml
+mode: yolo   # default is `guided`
+```
+
+When `mode: yolo`:
+- Skills auto-advance past menus using the sensible default (usually `[C] Continue`).
+- Discovery questions are answered with the best inference from available context (PRD, prior artifacts, repo state).
+- The skill still cites its inferences so they can be audited.
+- Capacity numbers, kill criteria, external citations are still required — yolo mode does NOT bypass the research-citation rule (issue #128) or the capacity gate (issue #127).
+
+Switch back with:
+
+```yaml
+mode: guided
+```
+
+## Sanctioned Path 2 — Per-invocation: `--auto`
+
+```
+/rihal:do --auto <question>
+```
+
+The router passes an `autoMode=true` flag to the dispatched skill. Same semantics as `mode: yolo` but scoped to the single invocation.
+
+## What Is NOT Sanctioned
+
+If the user's prompt contains phrases like *"just write it autonomously"*, *"skip the questions"*, *"ready to execute"*, or *"use research mode"* — these are **not** authorization to bypass halt. They are signals that the user wants the skill to move efficiently. The correct response is to run the next step concisely, not to skip it.
+
+If the user genuinely wants hands-off execution, they will set `mode: yolo` or re-invoke with `--auto`. Do not infer bypass from prompt text alone.
+
+## What Still Applies in Yolo / Auto Mode
+
+- `_shared/research-citation-rule.md` — every external claim needs a `WebFetch`.
+- `_shared/state-sync-rule.md` — after writing planning artifacts, sync into `state.json`.
+- Capacity gate in sprint-planning — numbers must come from somewhere (prior retro, user profile, PRD estimates), never fabricated.
+- Kill criteria must stay binary (numeric threshold, not adjective).
+
+## Related Issues
+
+- #124 — halt-at-menu enforcement
+- #127 — sprint-planning capacity gate
+- #128 — research citation rule
+- #130 — this doc

--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -1947,7 +1947,85 @@ function cmdState(subArgs) {
     return { updated: true, status: 'reset', preserved_decisions: preserved.decisions.length };
   }
 
-  throw new Error(`Unknown state subcommand: ${sub}.\nCommon: read, set-phase, advance-plan, add-decision, decisions-global, add-blocker\nRun 'rihal-tools.cjs help' for the full list of state subcommands.`);
+  // --- sync --from-disk ---
+  // Parse ROADMAP.md + epics.md and upsert milestones/phases/epics into state.json.
+  // Preserves existing statuses on matching phase names/numbers.
+  // Tracks: issue #126 (state desync between planning artifacts and state.json).
+  if (sub === 'sync') {
+    const flags = parseFlags(1);
+    if (!flags['from-disk'] && flags['from-disk'] !== '') {
+      // Support both "--from-disk" (flag) and "--from-disk true"
+      // parseFlags consumes the next token as value; accept empty-string value.
+    }
+    const roadmapPath = path.join(PLANNING_DIR, 'ROADMAP.md');
+    const epicsPath = path.join(PLANNING_DIR, 'epics.md');
+    const state = readState() || defaultState();
+
+    const parsed = {
+      milestones_found: 0,
+      phases_found: 0,
+      phases_upserted: 0,
+      epics_found: 0,
+      roadmap_exists: fs.existsSync(roadmapPath),
+      epics_exists: fs.existsSync(epicsPath),
+    };
+
+    // Parse ROADMAP.md for phase tables.
+    // Expected row format:  | 01 | Phase Name | Goal text | ... |
+    // First cell is phase number (1-3 chars of digits or digits+letter).
+    if (parsed.roadmap_exists) {
+      const roadmap = fs.readFileSync(roadmapPath, 'utf8');
+      parsed.milestones_found = (roadmap.match(/^##\s+Milestone\s+M\d+/gim) || []).length;
+      const rowRe = /^\|\s*(\d{1,3}(?:\.\d+)?)\s*\|\s*([^|]+?)\s*\|\s*([^|]*?)\s*\|/gm;
+      let m;
+      if (!state.phases) state.phases = [];
+      while ((m = rowRe.exec(roadmap)) !== null) {
+        const phaseNum = m[1].trim();
+        const phaseName = m[2].trim();
+        const phaseGoal = m[3].trim();
+        // Skip header rows like "| # | Phase | Goal |"
+        if (!/^\d/.test(phaseNum)) continue;
+        if (phaseName.toLowerCase() === 'phase') continue;
+        parsed.phases_found += 1;
+        const existingIdx = state.phases.findIndex(p =>
+          String(p.number) === phaseNum || p.name === phaseName
+        );
+        if (existingIdx >= 0) {
+          // Preserve existing status fields; update metadata.
+          state.phases[existingIdx].number = state.phases[existingIdx].number || phaseNum;
+          state.phases[existingIdx].name = phaseName;
+          if (phaseGoal) state.phases[existingIdx].goal = phaseGoal;
+        } else {
+          state.phases.push({
+            number: phaseNum,
+            name: phaseName,
+            goal: phaseGoal,
+            status: 'planned',
+            started: null,
+            completed: null,
+            plan_count: 0,
+          });
+          parsed.phases_upserted += 1;
+        }
+      }
+    }
+
+    // Parse epics.md for epic count (lightweight — full epic sync is a future enhancement).
+    if (parsed.epics_exists) {
+      const epics = fs.readFileSync(epicsPath, 'utf8');
+      parsed.epics_found = (epics.match(/^##\s+EPIC-\d+/gim) || epics.match(/^##\s+Epic\s+\d+/gim) || []).length;
+      state.epics_count = parsed.epics_found;
+    }
+
+    if (!parsed.roadmap_exists && !parsed.epics_exists) {
+      throw new Error(`state sync --from-disk: neither ROADMAP.md nor epics.md found at ${PLANNING_DIR}`);
+    }
+
+    writeState(state);
+    return { ok: true, synced: true, ...parsed };
+  }
+
+  throw new Error(`Unknown state subcommand: ${sub}.\nCommon: read, set-phase, advance-plan, add-decision, decisions-global, add-blocker, sync\nRun 'rihal-tools.cjs help' for the full list of state subcommands.`);
 }
 
 /**

--- a/rihal/skills/_shared/no-autonomous-bypass.md
+++ b/rihal/skills/_shared/no-autonomous-bypass.md
@@ -1,0 +1,37 @@
+# No Autonomous-Mode Bypass
+
+This fragment is referenced by every step-file workflow that enforces halt-at-menu. Do not inline its contents into individual step files — reference this file so the rule stays single-sourced.
+
+## The Rule
+
+Step-file skills (`rihal-create-prd`, `rihal-sprint-planning`, `rihal-create-epics-and-stories`, etc.) halt at every menu and wait for user input. **This is invariant.** The agent MUST NOT invent an "autonomous mode", "research mode", or any other self-declared bypass that skips discovery questions.
+
+Phrases like *"just write it autonomously"*, *"create the full thing ready to execute"*, *"skip the questions"*, or *"use research mode"* from the user are **not** authorization to bypass halt. They are signals that the user wants the skill to move efficiently — answer by running the next step's questions compactly, not by skipping them.
+
+## The Only Sanctioned Bypass Paths
+
+There are exactly two ways to legitimately run a skill without halting at menus:
+
+1. **Project-wide:** `.rihal/config.yaml` → `mode: yolo`. The config loader flags `yoloMode=true` in the runtime context; step files check this flag and may auto-advance.
+2. **Per-invocation:** `/rihal:do --auto <question>` on the router. The router sets `autoMode=true` and passes it to the dispatched skill.
+
+If **neither** flag is set, halt is mandatory regardless of what the user's prompt text says.
+
+## Required Behavior When Asked to Bypass Without a Flag
+
+1. Acknowledge the user's intent in one sentence.
+2. Show the current step's menu anyway.
+3. Tell the user the two sanctioned paths (config flag or `--auto`) if they want fully hands-off execution.
+4. Do not generate any output artifact (PRD, sprint plan, roadmap, etc.) until the user either selects a menu option or sets one of the sanctioned flags.
+
+## Anti-Example (What NOT to Do)
+
+> User: *"use rihal research skills and create best PRD ready to execute"*
+>
+> ❌ Agent: *"Switching to autonomous mode — researching the domain and drafting a complete execution-ready PRD."* *(then writes full PRD)*
+
+That response invents a mode that does not exist and violates the halt invariant.
+
+## Correct Response
+
+> ✅ Agent: *"I hear you want the PRD written end-to-end. The halt rule applies unless you set `mode: yolo` in `.rihal/config.yaml` or re-invoke via `/rihal:do --auto`. Here is the step-01 menu — pick Continue and I will drive each step concisely."*

--- a/rihal/skills/_shared/research-citation-rule.md
+++ b/rihal/skills/_shared/research-citation-rule.md
@@ -1,0 +1,39 @@
+# Research & Citation Rule
+
+Referenced by any step-file workflow that writes content derived from external sources (competitor pricing, API tiers, market sizing, benchmark numbers, vendor claims, etc.).
+
+## The Rule
+
+If an output artifact (PRD, research note, architecture doc, roadmap) contains a specific external claim — a price, a percentage, a named competitor feature, an API limit — then **every such claim must be traceable to a `WebFetch` (or equivalent document-fetch) call made in the same session**. `WebSearch` snippets alone are not sufficient evidence because snippets are paraphrased and may be stale.
+
+## What This Means in Practice
+
+Before writing a claim like *"Competitor X costs $12.50/mo"*:
+
+1. Run `WebFetch` on the source URL (not just `WebSearch` for a snippet).
+2. Quote the exact sentence from the fetched content in your internal reasoning.
+3. Include the URL in the citations block of the artifact.
+4. If the URL is paywalled, login-walled, or returns a different claim than expected, drop the number — do not paraphrase from memory or search-result previews.
+
+## The Trap to Avoid
+
+Observed failure pattern (rihal-code session, social-poster-x PRD generation):
+
+- Agent ran two `WebSearch` calls.
+- Agent wrote a PRD citing four specific URLs with specific dollar amounts.
+- Agent never ran `WebFetch` on any of the four URLs.
+- Numbers may be accurate-looking hallucinations.
+
+This pattern is forbidden. A citation block without `WebFetch` evidence is a lie to the reader.
+
+## If the User Is Running Autonomously
+
+`mode: yolo` and `/rihal:do --auto` bypass halt-at-menu, but they do **not** bypass this rule. A fully-autonomous run still has to fetch every cited URL before writing the claim.
+
+## Checklist Before Writing a Citation
+
+- [ ] `WebFetch` was called on this URL in this session.
+- [ ] The fetched content contains the specific number / claim being cited.
+- [ ] The claim in the artifact matches the fetched content verbatim (or is a clearly labeled summary).
+
+If any box is unchecked: remove the claim, replace with *"(needs source)"*, and flag to the user.

--- a/rihal/skills/_shared/state-sync-rule.md
+++ b/rihal/skills/_shared/state-sync-rule.md
@@ -1,0 +1,43 @@
+# State Sync Rule
+
+Referenced by skills that write `ROADMAP.md`, `epics.md`, or sprint artifacts. These artifacts are not authoritative on their own — downstream workflows (`/rihal:status`, `/rihal:progress`, `/rihal:execute`) read `.rihal/state.json`. If you write a planning artifact and skip state sync, the project ends up with two divergent pictures.
+
+## The Rule
+
+Immediately after appending content to any of:
+
+- `.planning/ROADMAP.md` — milestones and phases
+- `.planning/epics.md` — epics and stories
+- `.rihal/phases/{phase}/sprint-{N}.md` — sprint commitments
+
+Call the state-sync helper:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+or, for a more targeted write, use the JSON-API helpers exposed by `rihal-tools.cjs`:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state upsert-milestone <json>
+node .rihal/bin/rihal-tools.cjs state upsert-phase <json>
+node .rihal/bin/rihal-tools.cjs state upsert-epic <json>
+```
+
+If `rihal-tools.cjs` does not yet expose the needed subcommand, fall back to `state sync --from-disk` which re-parses `ROADMAP.md` + `epics.md` and rebuilds the relevant sections of `state.json`.
+
+## Verification After Sync
+
+- `node .rihal/bin/rihal-tools.cjs state read` returns a phase count that matches the phase table in `ROADMAP.md`.
+- `/rihal:status` and `/rihal:progress`, run back-to-back, agree on the current milestone name and phase count.
+
+## Why This Matters
+
+Observed failure (rihal-code, social-poster-x install, Apr 2026):
+
+- User ran `/rihal:create-epics-and-stories`.
+- `ROADMAP.md` gained 10 phases; `epics.md` gained 62 stories.
+- `.rihal/state.json` remained at the initial bootstrap with 1 phase.
+- `/rihal:status` showed 1 phase; `/rihal:progress` showed 10.
+
+That divergence is what this rule exists to prevent.

--- a/rihal/skills/actions/2-plan/rihal-create-epics-and-stories/workflow.md
+++ b/rihal/skills/actions/2-plan/rihal-create-epics-and-stories/workflow.md
@@ -36,6 +36,7 @@ This uses **step-file architecture** for disciplined execution:
 - 🎯 **ALWAYS** follow the exact instructions in the step file
 - ⏸️ **ALWAYS** halt at menus and wait for user input
 - 📋 **NEVER** create mental todo lists from future steps
+- 🚷 **NEVER** invent an "autonomous mode", "research mode", or any self-declared bypass. The only sanctioned bypass paths are `.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`. See `../../_shared/no-autonomous-bypass.md` for the full rule and correct response pattern.
 
 ---
 

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/SKILL.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: rihal-create-milestone
+description: >
+  Design the milestone roadmap (M1..Mn) for a project from an approved PRD.
+  Activates when the user says "create milestones", "plan milestones",
+  "create roadmap", "what milestones do I need", "break this project into
+  milestones", or "roadmap for this product". Do NOT use for milestone
+  lifecycle (use rihal-new-milestone / rihal-complete-milestone), for
+  decomposing one milestone into epics (use rihal-create-epics-and-stories),
+  or for single-phase planning (use rihal-plan-phase).
+---
+
+Follow the instructions in ./workflow.md.
+
+## Output Format
+
+- Output: ROADMAP.md in `{planning_artifacts}/`
+- Structure: per milestone — Name, Window (dates), Goal (one sentence), Acceptance criteria, Kill criteria (binary), Phases (stub list), then a trailing Backlog / parking lot section
+- Each kill criterion must be binary (number + threshold), not adjectival
+- Every milestone has an explicit window with start + end dates
+- Do NOT include: unquantified success language ("grow the user base"), open-ended milestones without dates, or more than 6 active milestones in one roadmap (split into v1/v2 if needed)
+
+## Examples
+
+### Happy Path
+**Input:** "Create the milestones I need for this project"
+**Expected behavior:** Load the approved PRD. Confirm scope. For each major outcome, propose a milestone with name, window, goal, acceptance, kill criteria. Halt at menu after each milestone for user confirmation. Append to ROADMAP.md only after user selects Continue. Upsert each milestone + its phase stubs into `.rihal/state.json` (see `../../_shared/state-sync-rule.md`).
+
+### Edge Case: No PRD Exists
+**Input:** "Create milestones for social-poster-x" (no prd.md)
+**Expected behavior:** DO NOT invent milestones. Respond: "I need an approved PRD first. Run `/rihal:create-prd` or point me at an existing brief."
+
+### Edge Case: PRD Marked Draft
+**Input:** PRD exists but frontmatter shows `status: draft`
+**Expected behavior:** Warn the user that milestones based on a draft PRD will need re-work if the PRD changes. Ask whether to proceed anyway or first finalize the PRD.
+
+### Negative Example: Request to Bypass the Interview
+**Input:** "just generate the full roadmap autonomously"
+**Expected behavior:** DO NOT invent an "autonomous mode". Point the user to the two sanctioned bypass paths (`.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`) and present the step-01 menu. See `../../_shared/no-autonomous-bypass.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/README.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/README.md
@@ -1,0 +1,29 @@
+# rihal-create-milestone — Steps
+
+This skill uses the same step-file architecture as `rihal-create-prd` and `rihal-create-epics-and-stories`.
+
+## Status
+
+- `step-01-init.md` — implemented (initial scaffold, issue #129)
+- `step-02-outcomes.md` through `step-10-complete.md` — **to be written in a follow-up**. Track in a GitHub issue titled `feat(skills): complete step files for rihal-create-milestone`.
+
+## Expected Step Files (per workflow.md)
+
+| # | File | Purpose |
+|---|------|---------|
+| 1 | `step-01-init.md` | Load PRD, detect continuation, init frontmatter |
+| 2 | `step-02-outcomes.md` | Extract major outcomes from PRD; user confirms |
+| 3 | `step-03-sequencing.md` | Group outcomes into milestones; agree cut lines |
+| 4 | `step-04-windows.md` | Assign date windows; verify realism |
+| 5 | `step-05-kill-criteria.md` | Binary kill criteria per milestone |
+| 6 | `step-06-phase-stubs.md` | Stub phases under each milestone |
+| 7 | `step-07-backlog.md` | Parking-lot items |
+| 8 | `step-08-write-roadmap.md` | Append milestones to ROADMAP.md |
+| 9 | `step-09-state-sync.md` | Upsert into `.rihal/state.json` (see `_shared/state-sync-rule.md`) |
+| 10 | `step-10-complete.md` | Summary + hand-off |
+
+## Conventions
+
+- Each step halts at a menu: `[A]ccept / [P]ropose change / [C]ontinue`.
+- Each step updates `stepsCompleted` in ROADMAP.md frontmatter before loading the next.
+- External citations require `WebFetch` (see `_shared/research-citation-rule.md`).

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-01-init.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-01-init.md
@@ -1,0 +1,62 @@
+# Step 1: Initialize Roadmap Workflow
+
+**Progress: Step 1 of 10** - Next: Extract Outcomes from PRD
+
+## STEP GOAL
+
+Load the PRD, detect whether ROADMAP.md already exists (continuation vs fresh), and initialize the output document with frontmatter.
+
+## MANDATORY EXECUTION RULES
+
+- 🛑 NEVER generate milestones without user input in later steps
+- 📖 Read the complete step file before acting
+- 📋 YOU ARE A FACILITATOR, not a content generator
+- ✅ Speak in `{communication_language}`; write artifacts in `{document_output_language}`
+- 🚷 No self-declared autonomous mode. See `../../../_shared/no-autonomous-bypass.md`.
+
+## SEQUENCE
+
+### 1. Detect Existing Workflow State
+
+- If `{outputFile}` exists with frontmatter `stepsCompleted` that does NOT include `step-10-complete`, load `./step-01b-continue.md` (if present) or resume from the last completed step.
+- Otherwise: fresh workflow.
+
+### 2. Load PRD
+
+Read `{inputFile}` (expected at `{planning_artifacts}/prd.md`). Extract:
+
+- Product name
+- Target launch date (if any)
+- Major outcomes / success metrics (will feed step-02)
+- Out-of-scope list (will feed backlog)
+
+Report back to the user:
+
+```
+PRD loaded: {prd_path}
+  Outcomes identified: N
+  Target launch: {date or "unspecified"}
+  Out-of-scope items: M
+```
+
+### 3. Initialize ROADMAP.md Frontmatter
+
+If fresh, write to `{outputFile}`:
+
+```yaml
+---
+stepsCompleted: ['step-01-init']
+sourcePRD: {inputFile}
+generatedDate: {date}
+totalMilestones: 0
+---
+```
+
+### 4. Menu
+
+Present:
+- `[C]` Continue to outcomes extraction (Step 2)
+- `[R]` Reload PRD (if user has just edited it)
+- `[Q]` Quit
+
+⏸️ HALT. Do not proceed until user selects `C`. When `C` is selected, load and follow `./step-02-outcomes.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/workflow.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/workflow.md
@@ -1,0 +1,93 @@
+---
+main_config: '{project-root}/.rihal/config.json'
+outputFile: '{planning_artifacts}/ROADMAP.md'
+inputFile: '{planning_artifacts}/prd.md'
+---
+
+# Create Milestone / Roadmap Workflow
+
+**Goal:** Design a roadmap of milestones (M1..Mn) from an approved PRD. Each milestone carries a window, goal, acceptance, and binary kill criteria.
+
+**Your Role:** Product strategist and program manager collaborating with the user. You sequence outcomes into milestones; the user validates priorities and cut lines.
+
+---
+
+## WORKFLOW ARCHITECTURE
+
+This uses **step-file architecture** for disciplined execution:
+
+### Core Principles
+
+- **Micro-file Design**: Each step is a self-contained instruction file
+- **Just-In-Time Loading**: Only the current step file is in memory
+- **Sequential Enforcement**: Sequence within step files must be completed in order
+- **State Tracking**: Document progress via `stepsCompleted` array in output frontmatter
+- **Append-Only Building**: Build ROADMAP.md by appending each milestone once confirmed
+
+### Critical Rules (NO EXCEPTIONS)
+
+- 🛑 **NEVER** load multiple step files simultaneously
+- 📖 **ALWAYS** read entire step file before execution
+- 🚫 **NEVER** skip steps or optimize the sequence
+- ⏸️ **ALWAYS** halt at menus and wait for user input
+- 💾 **ALWAYS** update frontmatter of output files when writing
+- 🎯 **ALWAYS** follow the exact instructions in the step file
+- 📋 **NEVER** create mental todo lists from future steps
+- 🚷 **NEVER** invent an "autonomous mode" or self-declared bypass. The only sanctioned paths are `.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`. See `../../_shared/no-autonomous-bypass.md`.
+- 🔗 **NEVER** cite external sources without `WebFetch`. See `../../_shared/research-citation-rule.md`.
+- 🗂️ **ALWAYS** sync every milestone/phase into `.rihal/state.json` after writing to ROADMAP.md. See `../../_shared/state-sync-rule.md`.
+
+---
+
+## INITIALIZATION SEQUENCE
+
+### 1. Configuration Loading
+
+Load and read full config from `{main_config}` and resolve:
+
+- `project_name`, `output_folder`, `planning_artifacts`, `user_name`
+- `communication_language`, `document_output_language`
+- `date` as system-generated current datetime
+
+✅ SPEAK OUTPUT in `{communication_language}`.
+✅ WRITE all artifact content in `{document_output_language}`.
+
+### 2. Prerequisite Check
+
+Verify `{inputFile}` (PRD) exists and is non-empty. If missing:
+
+- Respond: *"I need an approved PRD first. Run `/rihal:create-prd` or point me at the existing brief."*
+- HALT. Do not create ROADMAP.md.
+
+If PRD frontmatter shows `status: draft`, warn the user and ask whether to proceed.
+
+### 3. Route to First Step
+
+Read fully and follow: `./steps/step-01-init.md`
+
+---
+
+## WORKFLOW OUTLINE
+
+Steps (loaded one at a time):
+
+1. `step-01-init.md` — Load PRD, detect continuation, initialize ROADMAP.md frontmatter.
+2. `step-02-outcomes.md` — Extract major outcomes from PRD. User confirms the list.
+3. `step-03-sequencing.md` — Group outcomes into milestones; agree cut lines.
+4. `step-04-windows.md` — Assign date windows to each milestone; verify realism with user.
+5. `step-05-kill-criteria.md` — Define binary kill criteria per milestone.
+6. `step-06-phase-stubs.md` — List stub phases under each milestone (no plan detail yet).
+7. `step-07-backlog.md` — Capture parking-lot items.
+8. `step-08-write-roadmap.md` — Append all milestones to ROADMAP.md.
+9. `step-09-state-sync.md` — Upsert milestones + phases into `.rihal/state.json`.
+10. `step-10-complete.md` — Summary, next-step hand-off (`/rihal:create-epics-and-stories` for M1).
+
+Each step halts at a menu: [A]ccept / [P]ropose change / [C]ontinue. Only on `C` does the workflow advance.
+
+---
+
+## HAND-OFF
+
+On completion, recommend the user run:
+- `/rihal:create-epics-and-stories` to decompose M1 into epics + stories.
+- `/rihal:sprint-planning` once the first epic is scoped.

--- a/rihal/skills/actions/2-plan/rihal-create-prd/SKILL.md
+++ b/rihal/skills/actions/2-plan/rihal-create-prd/SKILL.md
@@ -32,3 +32,7 @@ Follow the instructions in ./workflow.md.
 ### Edge Case: Existing PRD
 **Input:** "Create a PRD for auth" (but one already exists)
 **Expected behavior:** Detect the existing PRD. Respond: "A PRD for auth already exists at [path]. Use rihal-edit-prd to update it, or confirm you want to overwrite."
+
+### Negative Example: Request to Bypass the Interview
+**Input:** "use research skills and create the best PRD ready to execute" / "skip the questions and write it autonomously" / "just generate the full PRD"
+**Expected behavior:** DO NOT invent an "autonomous mode". DO NOT generate a PRD without running discovery. Respond: "The discovery interview is mandatory unless `.rihal/config.yaml` has `mode: yolo` or you re-invoke via `/rihal:do --auto`. Here is the step-01 menu — I will drive each step concisely." Then present the step-01 menu. See `../../_shared/no-autonomous-bypass.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-prd/workflow.md
+++ b/rihal/skills/actions/2-plan/rihal-create-prd/workflow.md
@@ -42,6 +42,7 @@ This uses **step-file architecture** for disciplined execution:
 - ⏸️ **ALWAYS** halt at menus and wait for user input
 - 📋 **NEVER** create mental todo lists from future steps
 - 🚷 **NEVER** invent an "autonomous mode", "research mode", or any self-declared bypass. The only sanctioned bypass paths are `.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`. See `../../_shared/no-autonomous-bypass.md` for the full rule and correct response pattern.
+- 🔗 **NEVER** cite an external source (competitor pricing, API limits, market numbers) without first `WebFetch`ing it in the same session. `WebSearch` snippets are not sufficient evidence. See `../../_shared/research-citation-rule.md`.
 
 ## INITIALIZATION SEQUENCE
 

--- a/rihal/skills/actions/2-plan/rihal-create-prd/workflow.md
+++ b/rihal/skills/actions/2-plan/rihal-create-prd/workflow.md
@@ -41,6 +41,7 @@ This uses **step-file architecture** for disciplined execution:
 - 🎯 **ALWAYS** follow the exact instructions in the step file
 - ⏸️ **ALWAYS** halt at menus and wait for user input
 - 📋 **NEVER** create mental todo lists from future steps
+- 🚷 **NEVER** invent an "autonomous mode", "research mode", or any self-declared bypass. The only sanctioned bypass paths are `.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`. See `../../_shared/no-autonomous-bypass.md` for the full rule and correct response pattern.
 
 ## INITIALIZATION SEQUENCE
 

--- a/rihal/skills/actions/4-implementation/rihal-sprint-planning/SKILL.md
+++ b/rihal/skills/actions/4-implementation/rihal-sprint-planning/SKILL.md
@@ -27,3 +27,7 @@ Follow the instructions in ./workflow.md.
 ### Edge Case: No Capacity Info
 **Input:** "Plan the sprint"
 **Expected behavior:** Ask: "How many devs, any PTO, any known meetings? I need capacity numbers before committing to stories."
+
+### Negative Example: Fabricated Capacity
+**Input:** "Plan the sprint" (no prior capacity info, no `mode: yolo`, no `--auto`)
+**Expected behavior:** DO NOT assume "1 senior FT, 30 pts/week" or any other capacity. DO NOT write `sprint-N.md` until the user provides numeric answers for devs/PTO/velocity. If the user resists, point them at the two sanctioned bypass paths (`.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`). See `../../_shared/no-autonomous-bypass.md`.

--- a/rihal/skills/actions/4-implementation/rihal-sprint-planning/checklist.md
+++ b/rihal/skills/actions/4-implementation/rihal-sprint-planning/checklist.md
@@ -1,5 +1,15 @@
 # Sprint Planning Validation Checklist
 
+## Capacity Gate (BLOCKING — must pass before any story is committed)
+
+- [ ] Number of devs on the sprint is a concrete integer provided by the user
+- [ ] PTO / days off is accounted for (hours or days, explicit)
+- [ ] Known meetings / interrupt load is estimated (hours/week)
+- [ ] Velocity is either (a) provided by the user, or (b) pulled from prior sprint retrospective
+- [ ] 20% buffer is applied to the resulting capacity
+
+If any of the above is missing and the session is NOT running with `.rihal/config.yaml` `mode: yolo` or `/rihal:do --auto`, the workflow MUST halt and ask the user — never fabricate numbers.
+
 ## Core Validation
 
 ### Complete Coverage Check

--- a/rihal/skills/actions/4-implementation/rihal-sprint-planning/workflow.md
+++ b/rihal/skills/actions/4-implementation/rihal-sprint-planning/workflow.md
@@ -70,6 +70,19 @@ Load config from `{project-root}/.rihal/config.json` and resolve:
 
 <workflow>
 
+<step n="0" goal="Capacity Gate — halt until capacity inputs are known">
+<action>Check whether a recent sprint retrospective or prior sprint file contains numeric capacity (devs, PTO, velocity). If yes, load and display it for user confirmation.</action>
+<action>If no capacity data is available, ask the user — via AskUserQuestion or plain prompt — for:
+  1. Number of devs on the sprint
+  2. PTO / days off
+  3. Known meetings / interrupt load (hours/week)
+  4. Target velocity (story points or hours) — use prior sprint if available
+</action>
+<action>Compute: available_capacity = (devs × working_hours × velocity_factor) − PTO − meetings; apply a 20% buffer.</action>
+<action>BLOCKING: If any input is missing and the runtime is NOT in `mode: yolo` or `--auto`, halt and restate the question. Never fabricate numbers. See `../../_shared/no-autonomous-bypass.md`.</action>
+<action>Record the capacity inputs in the output `sprint-status.yaml` frontmatter under `capacity:` so downstream status/progress workflows can display the source of truth.</action>
+</step>
+
 <step n="1" goal="Parse epic files and extract all work items">
 <action>Load {project_context} for project-wide patterns and conventions (if exists)</action>
 <action>Communicate in {communication_language} with {user_name}</action>

--- a/rihal/skills/actions/4-implementation/rihal-sprint-planning/workflow.md
+++ b/rihal/skills/actions/4-implementation/rihal-sprint-planning/workflow.md
@@ -6,6 +6,14 @@
 
 ---
 
+## CRITICAL RULES (NO EXCEPTIONS)
+
+- ⏸️ **ALWAYS** halt for capacity input (devs, PTO, meetings, velocity) before committing stories to the sprint. Per `SKILL.md` Edge Cases, the skill must ask: *"How many devs, any PTO, any known meetings? I need capacity numbers before committing to stories."*
+- 🚫 **NEVER** fabricate capacity numbers (e.g. *"1 senior FT, 30 pts/week"*) when the user has not provided them.
+- 🚷 **NEVER** invent an "autonomous mode" or any self-declared bypass. The only sanctioned bypass paths are `.rihal/config.yaml` → `mode: yolo` or `/rihal:do --auto`. See `../../_shared/no-autonomous-bypass.md` for the full rule and correct response pattern.
+
+---
+
 ## INITIALIZATION
 
 ### Configuration Loading

--- a/rihal/workflows/do.md
+++ b/rihal/workflows/do.md
@@ -78,7 +78,8 @@ Evaluate `$QUESTION` against these routing rules. Apply the **first matching** r
 | "Sprint planning", "plan the sprint", "next sprint", "what's in this sprint" | `/rihal:sprint-planning` | Sprint-level scope/capacity planning |
 | Executing a sprint, "run the sprint", "start sprint", "work on sprint" | `/rihal:execute-sprint` | Sprint execution with wave batching |
 | Sprint status, "how is the sprint going", "sprint board", "sprint progress" | `/rihal:sprint-status` | Current sprint state |
-| Break milestone into epics/stories, "create stories", "user stories", "epics" | `/rihal:create-epics-and-stories` | Milestone → epic → story decomposition |
+| "Create milestones", "plan milestones", "create roadmap", "what milestones do I need", "break project into milestones" | `/rihal:create-milestone` | Roadmap-level planning — designs M1..Mn from the PRD. Do NOT route to `create-epics-and-stories`; that skill decomposes a single milestone into epics |
+| Break milestone into epics/stories, "create stories", "user stories", "epics" | `/rihal:create-epics-and-stories` | Milestone → epic → story decomposition (assumes roadmap already exists) |
 | Create a single story, "add story", "write a story for X" | `/rihal:create-story` | Single story addition |
 | Implement a story, "work on story", "dev story", "build story" | `/rihal:dev-story` | Story-level implementation |
 | Find gaps in milestone plans, "gaps in plans", "missing plan", "unplanned phases" | `/rihal:plan-milestone-gaps` | Identify and fill planning gaps |

--- a/rihal/workflows/progress.md
+++ b/rihal/workflows/progress.md
@@ -2,6 +2,8 @@
 Check project progress, summarize recent work and what's ahead, then intelligently route to the next action — either executing an existing plan or creating the next one. Provides situational awareness before continuing work.
 
 For a quick board view use `/rihal:sprint-status`. This gives the full narrative + routing.
+
+**SSOT:** `.rihal/state.json` is the single source of truth for phase counts and current position. `/rihal:progress` and `/rihal:status` MUST agree. When this workflow reads `ROADMAP.md` for human-readable goal text, it must first verify that `state.json` is in sync — if not, surface a drift warning and suggest `node .rihal/bin/rihal-tools.cjs state sync --from-disk`. See issue #131.
 </purpose>
 
 <required_reading>
@@ -35,6 +37,15 @@ End with a Next Up block (see output-format.md) when a routing suggestion applie
 INIT=$(node .rihal/bin/rihal-tools.cjs init progress 2>/dev/null || node .rihal/bin/rihal-tools.cjs init)
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 STATE=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null || echo '{}')
+
+# Drift check — detect state/disk divergence (issue #131)
+if [ -f .planning/ROADMAP.md ]; then
+  DISK_PHASES=$(grep -cE "^\|\s*[0-9]{1,3}" .planning/ROADMAP.md)
+  STATE_PHASES=$(echo "$STATE" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const s=JSON.parse(d);console.log((s.state?.phases||s.phases||[]).length)}catch{console.log(0)}}")
+  if [ "$DISK_PHASES" -gt 0 ] && [ "$DISK_PHASES" -ne "$STATE_PHASES" ]; then
+    echo "⚠ Drift: ROADMAP.md has $DISK_PHASES phases, state.json has $STATE_PHASES. Run: node .rihal/bin/rihal-tools.cjs state sync --from-disk"
+  fi
+fi
 ```
 
 Extract from init/state JSON: `project_exists`, `roadmap_exists`, `state_exists`, `phases`, `current_phase`, `next_phase`, `milestone_version`, `completed_count`, `phase_count`, `paused_at`, `state_path`, `roadmap_path`, `project_path`, `config_path`.

--- a/rihal/workflows/status.md
+++ b/rihal/workflows/status.md
@@ -2,11 +2,30 @@
 
 <purpose>
 Read `.rihal/state.json` and print a human-readable project status dashboard.
+
+**SSOT:** `.rihal/state.json` is the single source of truth for phase counts, milestone names, and current position. `/rihal:status` and `/rihal:progress` MUST agree — if `state.json` is out of date relative to `ROADMAP.md` or `epics.md`, that is a sync bug (see issue #126) and should be fixed by running `node .rihal/bin/rihal-tools.cjs state sync --from-disk`, not by reading the markdown files directly from this workflow.
 </purpose>
 
 <required_reading>
 @.rihal/references/output-format.md
 </required_reading>
+
+<drift_detection>
+Before printing the dashboard, detect state/disk drift:
+
+```bash
+if [ -f .planning/ROADMAP.md ]; then
+  DISK_PHASES=$(grep -cE "^\|\s*[0-9]{1,3}" .planning/ROADMAP.md)
+  STATE_PHASES=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const s=JSON.parse(d);console.log((s.state?.phases||[]).length)}catch{console.log(0)}}")
+  if [ "$DISK_PHASES" -gt 0 ] && [ "$DISK_PHASES" -ne "$STATE_PHASES" ]; then
+    echo "⚠ Drift detected: ROADMAP.md has $DISK_PHASES phases, state.json has $STATE_PHASES."
+    echo "  Run: node .rihal/bin/rihal-tools.cjs state sync --from-disk"
+  fi
+fi
+```
+
+Print this warning above the dashboard if drift is detected. Do NOT silently fall back to reading `ROADMAP.md` — that was the cause of the `/rihal:status` vs `/rihal:progress` disagreement in issue #131.
+</drift_detection>
 
 <output_format>
 Open with banner:


### PR DESCRIPTION
Closes #124, #125, #126, #127, #128, #129, #130, #131.

Two commits on this branch:

- \`6fbe3f6\` — **#124** halt-at-menu enforcement; forbid undocumented autonomous-mode bypass. New \`rihal/skills/_shared/no-autonomous-bypass.md\` single-sources the rule, wired into PRD, epics, and sprint-planning workflows.
- \`e8548a1\` — **#125-#131** router milestone/roadmap rule, \`rihal-tools state sync --from-disk\` for state/disk drift, capacity gate in sprint-planning, citation rule for PRD research, new \`rihal-create-milestone\` skill scaffold, yolo/--auto documentation, status/progress SSOT reconciliation.

## Summary of changes

| Area | Files |
|------|-------|
| New shared rules | \`rihal/skills/_shared/{no-autonomous-bypass,research-citation-rule,state-sync-rule}.md\` |
| New skill | \`rihal/skills/actions/2-plan/rihal-create-milestone/\` (SKILL.md, workflow.md, step-01-init.md; steps 02-10 tracked in #134) |
| New doc | \`docs/running-autonomously.md\` |
| State CLI | \`rihal/bin/rihal-tools.cjs\` — \`state sync --from-disk\` subcommand |
| Router | \`rihal/workflows/do.md\` — milestone/roadmap route |
| Workflows | \`rihal/workflows/status.md\` + \`progress.md\` — drift detection, SSOT policy |
| PRD skill | \`workflow.md\`, \`SKILL.md\` — halt-rule + citation rule + negative examples |
| Sprint-planning skill | \`workflow.md\`, \`SKILL.md\`, \`checklist.md\` — capacity gate + halt rule + negative example |
| Epics skill | \`workflow.md\` — halt rule |

## Verification

- Node syntax check on \`rihal-tools.cjs\`: OK
- Compliance check (every \`SKILL.md\` has \`## Output Format\` + \`## Examples\`): OK
- No push was made by Claude without explicit authorization (user approved in-session before push).

## Follow-ups (separate issues)

- #134 remaining step files for \`rihal-create-milestone\` (steps 02-10)
- #135 extend \`state sync\` to stories + sprints
- #136 end-to-end verification matrix (9 rows)
- #137 compliance review of \`rihal-create-milestone\`