### PR TITLE
docs(v2): repositioning narrative + public roadmap [M1 partial]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,65 @@
+# Rihal Code — Code Owners
+#
+# Routes PR reviews to the right person automatically. Each rule matches
+# a path pattern; only listed owners can approve changes to those paths.
+#
+# When Rihal GitHub teams are created, replace @hanzlahabib with
+# @rihal-om/<team> (e.g. @rihal-om/pm-team for rihal-hussain-pm).
+#
+# Catch-all fallback (last rule) points to the repo maintainer.
+
+# -------- Role-specific agent skills --------
+
+/rihal/skills/agents/hussain-pm/         @hanzlahabib
+/rihal/skills/agents/hussain-sm/         @hanzlahabib
+/rihal/skills/agents/raees-orchestrator/ @hanzlahabib
+
+/rihal/skills/agents/waleed-architect/   @hanzlahabib
+/rihal/skills/agents/ahmed-hassani-director/ @hanzlahabib
+/rihal/skills/agents/nasser-eng-manager/ @hanzlahabib
+
+/rihal/skills/agents/layla-designer/     @hanzlahabib
+/rihal/skills/agents/zahra-branding/     @hanzlahabib
+
+/rihal/skills/agents/yousef-backend/     @hanzlahabib
+/rihal/skills/agents/haitham-frontend/   @hanzlahabib
+/rihal/skills/agents/hanzla-engineer/    @hanzlahabib
+/rihal/skills/agents/zayd-ml/            @hanzlahabib
+
+/rihal/skills/agents/fatima-qa/          @hanzlahabib
+/rihal/skills/agents/noor-writer/        @hanzlahabib
+
+/rihal/skills/agents/sadiq-analyst/      @hanzlahabib
+/rihal/skills/agents/mariam-marketing/   @hanzlahabib
+/rihal/skills/agents/majlis-council/     @hanzlahabib
+
+# -------- Action skills by stage (PRDs, architecture, sprint, dev) --------
+
+# 1-analysis — discovery, research, market, PRFAQ, product-brief
+/rihal/skills/actions/1-analysis/        @hanzlahabib
+
+# 2-plan — PRD, epics/stories, milestone, UX design, architecture
+/rihal/skills/actions/2-plan/            @hanzlahabib
+
+# 3-solutioning — architecture decisions, research phase, solution design
+/rihal/skills/actions/3-solutioning/     @hanzlahabib
+
+# 4-implementation — dev-story, sprint-planning, code review, QA
+/rihal/skills/actions/4-implementation/  @hanzlahabib
+
+# -------- Shared rules (cross-cutting) --------
+# Changes here affect ALL skills; require extra scrutiny.
+/rihal/skills/_shared/                   @hanzlahabib
+
+# -------- Core infrastructure --------
+/rihal/bin/                              @hanzlahabib
+/cli/                                    @hanzlahabib
+/.github/                                @hanzlahabib
+/rihal/workflows/                        @hanzlahabib
+/rihal/commands/                         @hanzlahabib
+
+# -------- Brain content layer (v2.0) --------
+/rihal/brain/                            @hanzlahabib
+
+# -------- Catch-all --------
+*                                         @hanzlahabib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: release
+
+# Semver release pipeline (issue #161, M4 of v2.0 milestone).
+#
+# Triggers on annotated tag pushes matching v*. Runs the compliance
+# check, verifies the CLI syntax, builds the install bundle, and
+# attaches it to a GitHub Release along with the changelog section for
+# this version.
+#
+# Auth: NO tokens beyond GITHUB_TOKEN are required. The workflow does
+# not push, does not modify main, and does not create tags — tags are
+# created by a human via `git tag -a vX.Y.Z -m "..."` and `git push
+# origin vX.Y.Z`.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: CLI syntax check
+        run: node -c rihal/bin/rihal-tools.cjs
+
+      - name: 5-component skill compliance
+        run: |
+          missing=0
+          for f in rihal/skills/agents/*/SKILL.md rihal/skills/actions/*/*/SKILL.md; do
+            [ -f "$f" ] || continue
+            grep -q "^## Output Format" "$f" || { echo "MISSING Output Format: $f"; missing=$((missing+1)); }
+            grep -q "^## Examples" "$f"      || { echo "MISSING Examples: $f";      missing=$((missing+1)); }
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo "Compliance check failed — $missing missing section(s)"
+            exit 1
+          fi
+          echo "Compliance OK."
+
+      - name: Brain sources dry-run
+        run: |
+          # brain list must return valid JSON with ok:true; don't crash on placeholder URLs
+          node rihal/bin/rihal-tools.cjs brain list > /tmp/brain-list.json
+          grep -q '"ok": true' /tmp/brain-list.json || {
+            echo "brain list did not return ok:true"
+            cat /tmp/brain-list.json
+            exit 1
+          }
+          echo "Brain sources configuration OK."
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG"         >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog section for this version
+        id: changelog
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          # Slice CHANGELOG.md from `## ${TAG}` or `## v${VERSION}` down to
+          # the next `## ` heading — whichever matches first.
+          VERSION="${{ steps.version.outputs.version }}"
+          awk -v tag="$TAG" -v ver="v$VERSION" '
+            /^## / {
+              if (in_section) { exit }
+              if ($0 ~ tag || $0 ~ ver) { in_section = 1; print; next }
+            }
+            in_section { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "No CHANGELOG section found for $TAG — using fallback notes."
+            echo "# $TAG" > /tmp/release-notes.md
+            echo "" >> /tmp/release-notes.md
+            echo "See CHANGELOG.md for details." >> /tmp/release-notes.md
+          fi
+
+      - name: Build install bundle (tar.gz of the rihal/ + cli/ + docs/ tree)
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          mkdir -p dist
+          tar czf "dist/rihal-code-${TAG}.tar.gz" \
+            rihal/ cli/ docs/ \
+            README.md CHANGELOG.md CONTRIBUTING.md AGENTS.md package.json
+          ls -lh dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body_path: /tmp/release-notes.md
+          files: dist/rihal-code-*.tar.gz
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.tag, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Rihal Code are documented here.
 
 ---
 
+## v2.0.0 — Rihal Brain (unreleased)
+
+**Repositioning release.** Rihal Code is no longer a generic AI-engineering methodology that happens to be written at Rihal. It is **the installable context-brain for Rihalians** — every Rihal project can now pull PR standards, commit conventions, architecture docs, and internal guides straight from Rihal's own repos into the AI assistant's context on install.
+
+The v1 methodology, agents, and skills all remain. v2 adds the brain layer on top and reorganizes contribution around role-owners.
+
+Tracked in GitHub [milestone #4](https://github.com/hanzlahabib/rihal-code/milestone/4).
+
+### Added
+
+- **`docs/what-is-rihal-code.md`** — product story for the v2 repositioning.
+- **`docs/ROADMAP.md`** — public roadmap through v3.0 (MCP server) with binary kill criteria.
+- **`rihal/brain/`** — new content tree with `sources.yaml` (placeholder URLs until M5) and pull destinations for `rihal-github/`, `rihal-docs/`, and `best-practices/`.
+- **`rihal-tools brain pull`** — CLI subcommand that fetches configured sources via `git` sparse-checkout. Mirrors the `state sync --from-disk` pattern shipped in v1.0.0-beta.0 / issue #126.
+- **Install hook** runs `brain pull` automatically (graceful no-op when sources are placeholders).
+- **`.github/CODEOWNERS`** — per-role ownership enforcement so PM / CTO / UX / QA etc. changes route to the right reviewers.
+- **`CONTRIBUTING.md` — per-role guide** — one paragraph, one command sequence, one PR per role.
+- **`.github/workflows/release.yml`** — semver release pipeline: compliance check → bundle → GitHub release artefact.
+- **`docs/adr/mcp-design.md`** — design doc stub for the v3.0 MCP server (tracks open questions, not yet implemented).
+
+### Changed
+
+- **README.md** — new top section leads with the brain-in-a-box framing. Tier structure and methodology docs unchanged beneath it.
+- **`/rihal:update`** — now also runs `brain pull`, supports version pinning (`/rihal:update v1.3.0`).
+
+### Documentation
+
+- Public roadmap surfaces M2.5 (progress/status UX overhaul matching GSD-parity), M3 (role ownership), M4 (release pipeline), M5 (real Rihal content URLs), M6 (MCP).
+
+### Deferred to follow-up releases
+
+- **Full skill-folder reorganization under role owners** — CODEOWNERS ships in v2.0 covering the current folder layout; deeper reorg is a v2.1 scope.
+- **Elegant /progress and /status rebuild** (GSD-parity) — tracked as issue #159, landing in v2.5.
+- **Live MCP server** — v3.0 (design doc only in v2.0).
+
+---
+
 ## v1.0.0-beta.0 (2026-04-15)
 
 First beta release. v1 and v2 methodologies unified into a single landscape.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,41 @@ Thank you for contributing. These guidelines exist to keep the module maintainab
 
 ---
 
+## Who owns what — contribute to YOUR slice
+
+Rihal Code v2 is organized around **role ownership** (issue #160). Find your role, touch only that slice, open a focused PR. CODEOWNERS in `.github/CODEOWNERS` routes reviews automatically.
+
+| I am a… | Touch this | Why you'd edit |
+|---------|-----------|----------------|
+| **PM / Scrum Master** | `rihal/skills/agents/hussain-pm/`, `hussain-sm/`, `raees-orchestrator/` + `rihal/skills/actions/2-plan/` + `actions/1-analysis/` | Sharper PRD questions, better story templates, sprint-planning that matches how Rihal runs sprints |
+| **CTO / Architect** | `rihal/skills/agents/waleed-architect/`, `ahmed-hassani-director/`, `nasser-eng-manager/` + `rihal/skills/actions/3-solutioning/` | ADR structure, tech-selection criteria reflecting Rihal stack biases, arch-review gates |
+| **Designer / UX** | `rihal/skills/agents/layla-designer/`, `zahra-branding/` + `rihal/skills/actions/2-plan/rihal-create-ux-design/`, `rihal-frontend-design/` | Stronger design critiques, accessibility checks, Arabic-first RTL guidance |
+| **Backend / Frontend / ML** | `rihal/skills/agents/yousef-backend/`, `haitham-frontend/`, `zayd-ml/`, `hanzla-engineer/` + `rihal/skills/actions/4-implementation/` | Code-review checklists that catch the bugs Rihal sees in production, sprint capacity rules from lived experience |
+| **QA / Writer** | `rihal/skills/agents/fatima-qa/`, `noor-writer/` | Edge-case hunters, documentation patterns (README / API / ADR) |
+| **Strategy / Marketing** | `rihal/skills/agents/sadiq-analyst/`, `mariam-marketing/`, `majlis-council/` + `rihal/skills/actions/1-analysis/` | Kill-criteria framing, GCC-first GTM patterns, council panel heuristics |
+| **Any role, cross-cutting rule** | `rihal/skills/_shared/` | **Rarely.** A change here affects every skill referencing the fragment. Bring a clear motivating failure; expect extra scrutiny. |
+| **Infra / CLI / workflows** | `rihal/bin/`, `cli/`, `rihal/workflows/`, `rihal/commands/`, `.github/` | New CLI subcommands (follow the `rihal-tools state sync` / `brain pull` patterns), new slash commands, CI tweaks |
+| **Rihal standards / brain content** | `rihal/brain/` + `rihal/skills/_shared/` | New cross-project Rihal standards. After issue #162 (M5), upstream Rihal-docs-repo changes flow here via `brain pull`. |
+
+### The four-step pattern
+
+1. **Branch off `main`:** `git checkout -b <role>/<short-slug>` (e.g. `pm/sharper-prd-questions`).
+2. **Edit one slice.** If you touch multiple roles' slices in one PR, split it.
+3. **Run the compliance check** (below in [Pull Request Standards](#pull-request-standards)).
+4. **Open PR.** CODEOWNERS auto-requests the right reviewer. Conventional Commits title. No AI attribution in messages.
+
+Example — a PM improving the PRD discovery step:
+
+```bash
+git checkout -b pm/sharper-prd-discovery
+# edit rihal/skills/actions/2-plan/rihal-create-prd/steps-c/step-02-discovery.md
+# run the compliance check
+git commit -am "feat(skills): sharper PRD discovery on pricing models"
+gh pr create --title "feat(skills): sharper PRD discovery on pricing models"
+```
+
+---
+
 ## 🚨 Critical Rule — Never Auto-Push
 
 **AI agents and automation tools working on this repository MUST NEVER push to any remote without explicit, interactive user approval on every push.**

--- a/README.md
+++ b/README.md
@@ -2,13 +2,23 @@
 
 <div dir="rtl">طريقة رحال</div>
 
-> **An AI engineering methodology — 44 agents, 93 slash commands, 3 execution modes, file-based state. Install in one command into any Claude Code, Cursor, or compatible AI IDE project.**
+> **Install Rihal's brain into your project in one command.** Every Rihalian — engineer, PM, designer, CTO, QA — gets an AI assistant that already knows how Rihal builds: PR standards, commit conventions, architecture patterns, sprint cadence, the Rihal team's agent personas. No onboarding. No prompting. Works in Claude Code, Cursor, and any compatible AI IDE.
+
+---
+
+## Why this exists
+
+Every Rihal project carries unwritten context — how we review PRs, what "done" means, how we sequence milestones, how PRDs travel from Product into Engineering. That context sits in people's heads, Slack, Notion, senior engineers' review comments. AI assistants pick it up never, because every new chat session starts knowing nothing about how Rihal works.
+
+**Rihal Code fixes that.** One install, and the AI knows. Every session. Every repo. Every Rihalian.
+
+See [`docs/what-is-rihal-code.md`](docs/what-is-rihal-code.md) for the full story, and [`docs/ROADMAP.md`](docs/ROADMAP.md) for where this is going (next: live MCP server in v3.0).
 
 ---
 
 ## 🚦 Start Here
 
-Rihal Code has a lot in it. To keep things approachable, everything is organized into **four tiers**:
+Rihal Code packages a lot. To keep things approachable, everything is organized into **four tiers**:
 
 | Tier | Who it's for | Start with |
 |------|--------------|-----------|
@@ -19,13 +29,13 @@ Rihal Code has a lot in it. To keep things approachable, everything is organized
 
 **Brand new?** Do the [Golden Path](docs/TIERS.md#-starter--the-golden-path): scaffold → PRD → stories → sprint → dev → review → status. Seven skills, one project, end-to-end.
 
-> **v1.0-beta:** v1 and v2 have been unified into a single methodology. One `install` command, one agent roster, one set of slash commands + phrase-activated skills. See release notes in `CHANGELOG.md`.
+> **v2.0 — Rihal Brain.** v1 was a generic AI-engineering methodology. v2 keeps all of that and adds the Rihal context layer on top: standards, guides, and institutional knowledge pulled fresh from Rihal's own repos on install and on `/rihal:update`. See [`CHANGELOG.md`](CHANGELOG.md) and the [v2.0 milestone](https://github.com/hanzlahabib/rihal-code/milestone/4).
 
 ---
 
 ## What is this
 
-Most AI tools give you one assistant pretending to be everything. **Rihal Code gives you a real team.**
+Most AI tools give you one assistant pretending to be everything. **Rihal Code gives you Rihal's team — and Rihal's brain — inside every project.**
 
 - **44 agents** with clear roles, cultural identity (Arabic names), and hard scope boundaries
 - **93 slash commands** covering research, planning, execution, verification, and recovery

--- a/cli/install.js
+++ b/cli/install.js
@@ -801,11 +801,39 @@ function install(opts) {
   // Seed .planning/ with starter ROADMAP + STATE so workflows work immediately
   const starterSeeded = seedStarterPlanning(opts.target, opts.projectName);
 
+  // Pull Rihal brain content (v2.0 — issue #158).
+  // Runs rihal-tools brain pull as a child process. Placeholder URLs
+  // are skipped gracefully so this does not fail a fresh install.
+  let brainReport = null;
+  try {
+    const { execFileSync } = require('child_process');
+    const toolsPath = path.join(opts.target, '.rihal', 'bin', 'rihal-tools.cjs');
+    if (fs.existsSync(toolsPath)) {
+      const out = execFileSync('node', [toolsPath, 'brain', 'pull'], {
+        cwd: opts.target,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      try { brainReport = JSON.parse(out); } catch {}
+    }
+  } catch (e) {
+    // brain pull is best-effort on install — do not fail the whole install
+    brainReport = { ok: false, error: String(e.message || e).slice(0, 200) };
+  }
+
   // Summary
   console.log('');
   console.log(`  Installed: ${copied} file${copied === 1 ? '' : 's'}`);
   if (skillsInstalled > 0) {
     console.log(`  Skills:    ${skillsInstalled} phrase-activated (in .claude/skills/)`);
+  }
+  if (brainReport && brainReport.ok) {
+    const pulledCount = (brainReport.pulled || []).length;
+    const skippedCount = (brainReport.skipped || []).length;
+    console.log(`  Brain:     ${pulledCount} source${pulledCount === 1 ? '' : 's'} pulled` +
+      (skippedCount ? `, ${skippedCount} skipped (placeholder URLs — see issue #162)` : ''));
+  } else if (brainReport && brainReport.error) {
+    console.log(`  Brain:     skipped (${brainReport.error})`);
   }
   if (skipped > 0) console.log(`  Skipped:   ${skipped} (already present, unchanged)`);
   if (opts.force && existedBefore) {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,96 @@
+# Rihal Code — Public Roadmap
+
+This roadmap is published so every Rihalian (and every curious observer) can see where Rihal Code is going next. Each release below has a scope, an acceptance signal, and is tracked in the GitHub milestone linked beside it.
+
+All dates are targets, not commitments. Scope and dates shift when reality shifts; the roadmap gets updated in the same PR that lands the change.
+
+---
+
+## Shipped
+
+### v1 — Methodology foundation (landed)
+- 35+ agents with cultural identity and hard scope boundaries.
+- 69 slash commands across research, planning, execution, verification, recovery.
+- File-based state in `.rihal/`.
+- Intent guards, plan verification, post-execute gates.
+- Global agents at `~/.rihal/agents/` for customization.
+
+---
+
+## Current milestone
+
+### v2.0 — Rihal Brain in a Box
+[Milestone #4](https://github.com/hanzlahabib/rihal-code/milestone/4) · active
+
+**Goal:** Every Rihalian who installs Rihal Code gets an AI assistant that already knows how Rihal builds — PR standards, commit conventions, architecture patterns, PRD shape, sprint cadence.
+
+| Phase | What it delivers | Issue |
+|-------|------------------|-------|
+| M1 — Repositioning | README + `docs/what-is-rihal-code.md` tell the new story | [#157](https://github.com/hanzlahabib/rihal-code/issues/157) |
+| M2 — Brain ingestion | `rihal/brain/` + `rihal-tools brain pull` + install hook | [#158](https://github.com/hanzlahabib/rihal-code/issues/158) |
+| M2.5 — Elegant /progress | CLI does the thinking, workflow does the rendering, intent-based Next Up | [#159](https://github.com/hanzlahabib/rihal-code/issues/159) |
+| M3 — Role ownership | CODEOWNERS per role folder + CONTRIBUTING.md per-role guide | [#160](https://github.com/hanzlahabib/rihal-code/issues/160) |
+| M4 — Release pipeline | Semver tags, `rihal:update v1.3.0` pinning, GitHub release bundle | [#161](https://github.com/hanzlahabib/rihal-code/issues/161) |
+| M5 — Real Rihal content | Fill `sources.yaml` with actual Rihal GitHub + docs URLs | [#162](https://github.com/hanzlahabib/rihal-code/issues/162) |
+
+### Kill criteria for v2.0
+Binary — if either fires, we cut scope or pivot:
+
+- After M5 ships, fewer than 3 role-owners open a single PR against their slice within 60 days → per-role contribution model has failed. Revisit.
+- `brain pull` against the real Rihal docs repo takes > 10s on fresh install → static model can't scale. Jump to MCP (v3.0) early.
+
+---
+
+## Next
+
+### v2.1 — Per-role contribution onboarding
+**Goal:** A new Rihalian can open a PR improving their role's skill in under 10 minutes, without reading the 5-component compliance doc first.
+
+- In-editor templates (`rihal/skills/templates/role/`) that pre-fill the correct structure.
+- `/rihal:scaffold-skill --role pm` command that generates a ready-to-fill skill.
+- Automated compliance check in CI (no reviewer time spent on structural issues).
+
+### v2.5 — Progress/status UX polish
+**Goal:** Running `/rihal:progress` or `/rihal:status` on any project feels as sharp as the GSD (Get Shit Done) sibling project.
+
+- Bundled into v2.0 as M2.5 (issue [#159](https://github.com/hanzlahabib/rihal-code/issues/159)) — listed here for the public roadmap view.
+- Pre-computed CLI output, insight block for drift, intent-tree Next Up.
+- Opt-in telemetry on skill invocations so we know what's actually used.
+
+---
+
+## On the horizon
+
+### v3.0 — MCP server
+**Goal:** No more `/rihal:update`. The Rihal brain is queried live; every Rihalian's AI always sees the latest Rihal standard the moment it's published.
+
+- Hosted on Rihal infra, authenticated via Rihal SSO.
+- Migration path: v2.0 and v3.0 run side-by-side for one release, then `brain pull` is deprecated.
+- Design doc tracked in [#163](https://github.com/hanzlahabib/rihal-code/issues/163).
+
+### v3.x — Internal Rihal registry
+**Goal:** Rihalians install from an internal source, not GitHub. Faster, access-controlled, audit-trailed.
+
+- Replaces `npx rihal-code@latest` as the primary install path for Rihal employees.
+- GitHub release stays available for non-Rihalian contributors and for transparency.
+
+---
+
+## Further out (not scheduled)
+
+These are ideas that have been raised but have no owner and no window. If you see one that matters, open an issue and make the case.
+
+- Multi-language brain content — Arabic versions of key docs for non-English-preferring contributors.
+- IDE-specific adapters beyond Claude Code / Cursor (JetBrains, Zed, VS Code native extension).
+- Rihal dashboard showing aggregate brain-content adoption across installed projects (opt-in).
+- Rihal council-as-a-service — spin up a council session from any Rihal project with one command.
+
+---
+
+## How to influence the roadmap
+
+- Open an issue with the `enhancement` label and a clear "why now" statement.
+- Start a `/rihal:council` session in a Rihal project to pressure-test the idea with multiple perspectives before filing.
+- PRs that align with a milestone get priority review from the role owner (see CODEOWNERS after M3 lands).
+
+The roadmap changes. This page is updated in the same PR that lands the change — never in isolation, never as a forward-promise without matching scope.

--- a/docs/adr/0003-mcp-server-for-rihal-brain.md
+++ b/docs/adr/0003-mcp-server-for-rihal-brain.md
@@ -1,0 +1,142 @@
+# ADR 0003 — MCP Server for the Rihal Brain (v3.0 direction)
+
+**Status:** Draft · Design stub, not yet approved
+**Date:** 2026-04-24
+**Supersedes:** nothing yet
+**Superseded by:** —
+**Tracks:** GitHub issue [#163](https://github.com/hanzlahabib/rihal-code/issues/163)
+
+---
+
+## Context
+
+Rihal Code v2.0 delivers Rihal's institutional context to every Rihalian's project through a **static + semi-dynamic** model: `rihal/brain/sources.yaml` lists upstream repos (GitHub org, Rihal docs repo, in-repo best-practices); `rihal-tools brain pull` clones those sources via sparse checkout; the pulled content sits under `rihal/brain/` until the next `/rihal:update`.
+
+This works for v2.0 but has three known limits:
+
+1. **Staleness between updates.** A Rihalian who runs `/rihal:update` on Monday sees Monday's standards all week, even if a critical PR-review rule is updated on Tuesday morning.
+2. **Pull cost compounds.** As Rihal's doc corpus grows, `brain pull` time grows linearly. The v2.0 kill criterion is 10s on fresh install — we will hit that.
+3. **No audit trail.** There is no record of which Rihalian's project is on which brain version, no telemetry on which standards are actually surfaced to the AI, no way to hot-fix a mistaken standard across all installations.
+
+An **MCP server** (Model Context Protocol) hosted on Rihal infrastructure would solve all three. Every Rihalian's IDE would register the Rihal MCP server; the AI queries it live for the relevant standard at the moment of relevance; Rihal sees aggregate usage and can push updates instantly.
+
+This ADR captures the design direction and the open questions we need to answer before writing a single line of server code.
+
+---
+
+## Decision (provisional — pending resolution of open questions below)
+
+Build a single Rihal-hosted MCP server that exposes the Rihal brain as:
+
+- **Resources** — each Rihal standard doc (PR standards, commit standards, architecture playbook sections) addressable by URI (e.g. `rihal://standards/pr-standards`).
+- **Tools** — query helpers, e.g. `getReviewChecklistFor(projectType)` returning the right section of the PR-review checklist based on the caller's project type.
+
+The v2.0 static pull remains available as an offline fallback and for non-Rihalians.
+
+---
+
+## Open questions (MUST be resolved before implementation)
+
+### Q1. Hosting
+
+**Options:**
+- A) Small Node service on Rihal's existing infra (GCP / AWS / Azure — which does Rihal already pay for?).
+- B) Cloudflare Workers (low latency, zero ops, edge-close).
+- C) Vercel Functions (Fluid Compute) for the Node runtime.
+- D) Self-hosted in Rihal office network only (security-max, availability-min).
+
+**Recommendation:** defer until Rihal ops team weighs in. If Rihal already has SSO + cloud infra, match that. If not, Cloudflare Workers is the lowest-friction starting point.
+
+### Q2. Authentication
+
+**Question:** how does the MCP server know the caller is a Rihalian?
+
+**Options:**
+- A) Rihal SSO (Google Workspace? Microsoft? which does Rihal use?).
+- B) Per-employee static API tokens provisioned via an admin UI.
+- C) Anonymous access — the content is not that sensitive, treat it like public docs.
+
+**Implication:** option A or B means we can surface **private Rihal standards** (internal review processes, deal-specific playbooks). Option C limits the server to public content.
+
+### Q3. Migration path from v2.0
+
+**Options:**
+- A) Side-by-side — v2.0 static pull and v3.0 MCP both work; `rihal/brain/` is the fallback when MCP is unreachable.
+- B) MCP-default — install flips to MCP registration by default; static pull is opt-in.
+- C) Hard cut — v3.0 removes static pull; everyone migrates or pins to v2.x.
+
+**Recommendation:** A for at least one release. Any network outage at Rihal should not disable every Rihalian's AI assistant.
+
+### Q4. Latency budget
+
+**Question:** how slow can the MCP server be before the user notices?
+
+**Rough budget:**
+- **P50 ≤ 100ms.** Below the threshold where the AI's overall response feels slower.
+- **P95 ≤ 300ms.** Occasional outliers acceptable.
+- **P99 ≤ 800ms.** Above this, fall back to cache.
+
+**Implication:** caching layer is mandatory. Consider a Cloudflare KV / Redis / Upstash tier sitting in front of whatever content store we pick.
+
+### Q5. Offline behavior
+
+**Question:** what does a Rihalian's AI see when they are on a plane / at home with bad wifi / on Rihal VPN disabled?
+
+**Decision:** MCP server MUST include an offline cache. The AI sees the last-seen version of each resource, with a warning banner ("brain cache from 2026-05-12 — you may be offline") injected into the first response of a session where live fetch failed.
+
+### Q6. What gets exposed as a Tool vs a Resource?
+
+**Resources** — content the AI reads (standards, playbooks, ADR excerpts).
+**Tools** — actions the AI calls (query a standard by project type; search standards by keyword; fetch Rihal's current release calendar).
+
+Initial scope: 10–15 resources, 3 tools. Grow after shipping.
+
+### Q7. Brain content update pipeline
+
+When a Rihal PM edits the PRD-review checklist in the Rihal docs repo and merges the PR, how does that change reach a Rihalian's AI within 5 minutes?
+
+**Options:**
+- A) Webhook from Rihal docs repo → MCP server's invalidation endpoint → cache eviction.
+- B) Polling — MCP server re-reads the docs repo every 5 minutes.
+- C) Pull-on-miss — first cache miss triggers a re-fetch.
+
+**Recommendation:** A + C together. Webhook for proactive invalidation; pull-on-miss as a safety net.
+
+---
+
+## Consequences
+
+### Positive
+- Rihalians always see current Rihal standards without running `/rihal:update`.
+- Rihal can push hot-fixes to mistaken standards within minutes.
+- Aggregate telemetry on what the AI actually surfaces to Rihalians — feedback loop for standards that are not landing.
+- Eliminates the 10s `brain pull` cost on every install.
+
+### Negative
+- New infrastructure to run and monitor (v2.0 needed no Rihal-side infra).
+- Availability coupling — MCP outage degrades every Rihalian's AI.
+- Auth complexity — SSO integration, token rotation, offboarding.
+- Higher initial investment than v2.0's "just `git clone`" approach.
+
+### Neutral
+- Non-Rihalians can still install Rihal Code; they just skip MCP registration and run on the static pull layer.
+
+---
+
+## Out of scope (for this ADR)
+
+- Specific MCP tool signatures — belongs in a follow-up ADR once the MCP server is running in dev.
+- Billing / cost projections — this is a design doc, not a budget.
+- Telemetry schema — separate ADR when privacy review happens.
+
+---
+
+## Next actions to approve this ADR
+
+1. Rihal ops picks a hosting option (Q1).
+2. Rihal IT picks an auth model (Q2).
+3. A Rihal engineer owns Q3-Q7 implementation design (separate ADR).
+4. This ADR is revisited, open questions become decisions, status flips to **Approved**.
+5. A v3.0 GitHub milestone is created and implementation tickets are filed.
+
+Until those four happen, v3.0 stays on the roadmap as a direction, and v2.0 + v2.5 carry the product.

--- a/docs/what-is-rihal-code.md
+++ b/docs/what-is-rihal-code.md
@@ -1,0 +1,88 @@
+# What is Rihal Code
+
+**Rihal Code is Rihal's brain, installable into any project in one command.**
+
+When a Rihalian — engineer, PM, designer, CTO, QA — opens Claude Code (or Cursor, or any compatible AI IDE) inside a project that has Rihal Code installed, the AI already knows how Rihal builds: the PR standards, the commit conventions, the architecture patterns, the way PRDs are written, the way milestones are sequenced, the way reviews are done. No prompting. No onboarding. The context is already in the room.
+
+That is the only job of this package.
+
+---
+
+## Why it exists
+
+Every Rihal project today carries unwritten context. How we review PRs. What "done" means. How architecture decisions are captured. How a sprint is planned. How a PRD is structured when it leaves a PM and lands in engineering. Which agent to consult when the question is strategic vs. tactical.
+
+That knowledge lives in people's heads, Slack history, Notion pages, senior engineers' review comments. New Rihalians pick it up slowly. AI assistants pick it up never — because every new chat session starts with the model knowing nothing about how Rihal works.
+
+Rihal Code fixes that. One install, and the AI now knows. Every session. Every repo. Every Rihalian.
+
+---
+
+## Who it's for
+
+- **Every Rihalian** building anything at Rihal. Engineer, PM, designer, CTO, QA, junior, senior, new hire. If you use an AI assistant to get work done, this is for you.
+- **Curious non-Rihalians** who want to see how a mature AI-engineering methodology is structured and packaged. The methodology itself is transferable; the Rihal-specific context is not — they'll be installing an empty brain with the scaffolding around it.
+
+---
+
+## What you get when you install it
+
+Running `npx rihal-code install` into a project produces:
+
+- **55+ phrase-activated skills** (from `/rihal:create-prd` to `/rihal:sprint-planning` to `/rihal:dev-story`) that route your request to the right workflow.
+- **35+ agents** — Rihal's team in AI form: Sadiq for strategy, Waleed for architecture, Hussain for product, Layla for UX, Fatima for QA, and more. Each has a hard scope boundary, so you know which one to talk to.
+- **File-based state** at `.rihal/` that every workflow reads and writes — project status, decisions, blockers, roadmap, sprints.
+- **The Rihal brain** at `rihal/brain/` (pulled fresh on install, refreshable with `/rihal:update`):
+  - PR / issue / commit standards from the Rihal GitHub org
+  - Architecture docs and internal guides from the Rihal docs repo
+  - Coding best practices accumulated from real Rihal projects
+- **Planning workflows** — council, research, plan, execute, verify, review — that match how Rihal actually runs sprints.
+
+---
+
+## What Rihal Code is *not*
+
+- Not a code generator. It does not write your app for you.
+- Not a replacement for your AI assistant. It makes Claude Code / Cursor / Codex *better* — it does not replace them.
+- Not a Rihal-only tool. Anyone can install it. The skills and agents work for anyone. The Rihal-specific brain content, however, is pulled from Rihal repos — non-Rihalians installing will get the scaffolding without the proprietary context.
+- Not a methodology book. It is the methodology, executable, inside your editor.
+
+---
+
+## Where the context comes from
+
+The brain is not baked into the package at build time. It is pulled live from three sources on install and on demand:
+
+1. **Rihal GitHub org** — PR standards, commit standards, issue standards live here.
+2. **Rihal docs repo** — architecture decisions, internal guides, role playbooks.
+3. **In-repo best practices** — accumulated from real project experience and owned inside this repo under `rihal/skills/_shared/`.
+
+Run `/rihal:update` any time to pull the latest. The pulled content is the single source of truth — local edits to installed brain files are overwritten on update (by design). If a Rihalian wants to change the standard, they contribute upstream to the Rihal docs repo or here — where every Rihalian benefits.
+
+---
+
+## What changes from v1 to v2
+
+Rihal Code v1 was a generic AI-engineering methodology. It worked for anyone, and any team could install it.
+
+Rihal Code v2 keeps all of that — and adds the Rihal brain layer on top. The repositioning is the product statement: Rihal Code is primarily for Rihalians now. The generic methodology is still there and still works, but the headline feature is the always-current Rihal context that makes every Rihalian's AI assistant feel like it's been working at Rihal for a year.
+
+---
+
+## Where this is going
+
+- **v2.0** — Brain in a box, static + semi-dynamic pull (where we are).
+- **v2.1** — Full per-role ownership: PM updates PM skills, CTO updates CTO skills. CODEOWNERS enforces. Contributing is one command, one PR.
+- **v2.5** — Progress/status UX overhaul: AI-friendly CLI output, intent-based "next-up" menus, drift detection.
+- **v3.0** — Live MCP server. No more `/rihal:update` needed. The brain is queried live; every Rihalian's AI always sees the latest Rihal standard the moment it's published.
+- **v3.x** — Internal Rihal package registry replaces GitHub release as the distribution channel.
+
+See `docs/ROADMAP.md` for the full roadmap.
+
+---
+
+## How to get involved
+
+If you are a Rihalian and the skill for your role doesn't match how you actually work — fix it. PM skills live under `rihal/skills/actions/2-plan/` (for planning artifacts) and `rihal/skills/agents/pm/` (for the agent personas). CTO / architecture skills live under `rihal/skills/agents/cto/` and `rihal/skills/actions/3-solutioning/`. CODEOWNERS routes your PR to the right reviewer automatically.
+
+See `CONTRIBUTING.md` for the per-role walkthrough. Every role gets one paragraph, one command sequence, one PR.

--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -2642,6 +2642,230 @@ function cmdNotesCount() {
   return { count };
 }
 
+/**
+ * cmdBrain — pull Rihal brain content from configured sources.
+ *
+ * Subcommands:
+ *   brain pull           Fetch all configured sources into rihal/brain/
+ *   brain pull <name>    Fetch a single named source
+ *   brain status         Report cache freshness and placeholder status
+ *   brain list           Print configured sources
+ *
+ * Uses git sparse-checkout so we pull only the paths listed per source.
+ * Placeholder URLs (containing `<PLACEHOLDER`) are skipped with a clear
+ * message — useful in v2.0 before M5 lands real Rihal repo URLs.
+ */
+function cmdBrain(args) {
+  const sub = args[0] || 'help';
+  const sourcesPath = path.join(PROJECT_ROOT, 'rihal', 'brain', 'sources.yaml');
+  const brainDir = path.join(PROJECT_ROOT, 'rihal', 'brain');
+
+  if (!fs.existsSync(sourcesPath)) {
+    return {
+      ok: false,
+      error: `sources.yaml missing at ${sourcesPath}. Run install or see issue #158.`,
+    };
+  }
+
+  // Minimal YAML reader specifically for sources.yaml — not a general parser.
+  // Handles: `version: 1`, `defaults:` block, `sources:` list where each
+  // entry is a `- name: X` block with sibling key: value lines and an
+  // `paths:` sub-list of strings.
+  function parseSourcesYaml(text) {
+    const root = { version: null, defaults: {}, sources: [] };
+    const lines = text.split('\n');
+    let section = null;
+    let current = null;     // current source map
+    let inPaths = false;
+    let inDescription = false;
+    let descLines = [];
+
+    function unquote(s) { return s.replace(/^['"]|['"]$/g, ''); }
+
+    for (const raw of lines) {
+      if (!raw.trim() || raw.trim().startsWith('#')) continue;
+
+      // Flush description if we were collecting
+      if (inDescription && raw.match(/^ {4}\S/) && !raw.trim().startsWith('-')) {
+        // still inside the description block
+        const m = raw.match(/^ *(.*)$/);
+        if (m) descLines.push(m[1]);
+        continue;
+      } else if (inDescription) {
+        current.description = descLines.join(' ').trim();
+        inDescription = false;
+        descLines = [];
+      }
+
+      // Top-level keys
+      const top = raw.match(/^(\w+):\s*(.*)$/);
+      if (top) {
+        const key = top[1], val = top[2].trim();
+        if (key === 'version') { root.version = unquote(val); section = null; continue; }
+        if (key === 'defaults') { section = 'defaults'; continue; }
+        if (key === 'sources') { section = 'sources'; continue; }
+      }
+
+      // defaults: indented key-value
+      if (section === 'defaults') {
+        const m = raw.match(/^ +([\w_]+):\s*(.*)$/);
+        if (m) root.defaults[m[1]] = unquote(m[2]);
+        continue;
+      }
+
+      // sources: list items
+      if (section === 'sources') {
+        const startItem = raw.match(/^ *- ([\w_-]+):\s*(.*)$/);
+        if (startItem) {
+          current = {};
+          current[startItem[1]] = unquote(startItem[2]);
+          root.sources.push(current);
+          inPaths = false;
+          continue;
+        }
+        // paths: list-of-strings under current
+        const pathsStart = raw.match(/^ +paths:\s*$/);
+        if (pathsStart) { current.paths = []; inPaths = true; continue; }
+        if (inPaths) {
+          const pItem = raw.match(/^ *- (.*)$/);
+          if (pItem) { current.paths.push(unquote(pItem[1])); continue; }
+          inPaths = false;
+        }
+        // description: block scalar `>`
+        const descStart = raw.match(/^ +description:\s*>\s*$/);
+        if (descStart) { inDescription = true; descLines = []; continue; }
+        // Regular key: value on current item
+        const kv = raw.match(/^ +([\w_-]+):\s*(.*)$/);
+        if (kv && current) {
+          current[kv[1]] = unquote(kv[2]);
+        }
+      }
+    }
+    // final flush
+    if (inDescription && current) current.description = descLines.join(' ').trim();
+    return root;
+  }
+
+  const cfg = parseSourcesYaml(fs.readFileSync(sourcesPath, 'utf8'));
+  const sources = Array.isArray(cfg.sources) ? cfg.sources : [];
+
+  if (sub === 'list') {
+    return {
+      ok: true,
+      version: cfg.version,
+      sources: sources.map(s => ({
+        name: s.name,
+        repo: s.repo,
+        dest: s.dest,
+        placeholder: String(s.repo || '').includes('<PLACEHOLDER'),
+      })),
+    };
+  }
+
+  if (sub === 'status') {
+    const report = { ok: true, sources: [] };
+    for (const s of sources) {
+      const destPath = path.join(PROJECT_ROOT, s.dest || '');
+      const exists = fs.existsSync(destPath);
+      report.sources.push({
+        name: s.name,
+        dest: s.dest,
+        fetched: exists,
+        placeholder: String(s.repo || '').includes('<PLACEHOLDER'),
+      });
+    }
+    return report;
+  }
+
+  if (sub !== 'pull') {
+    return {
+      ok: false,
+      error: `Unknown brain subcommand: ${sub}. Try: pull | status | list`,
+    };
+  }
+
+  // sub === 'pull'
+  const onlyName = args[1];
+  const report = { ok: true, pulled: [], skipped: [], errors: [] };
+
+  for (const s of sources) {
+    if (onlyName && s.name !== onlyName) continue;
+    const repo = String(s.repo || '');
+
+    if (repo.includes('<PLACEHOLDER')) {
+      report.skipped.push({ name: s.name, reason: 'placeholder URL — fill in via issue #162 (M5)' });
+      continue;
+    }
+
+    if (repo === 'self') {
+      // In-repo copy — use rsync-ish node copy from paths under project root.
+      const destPath = path.join(PROJECT_ROOT, s.dest);
+      fs.mkdirSync(destPath, { recursive: true });
+      const paths = Array.isArray(s.paths) ? s.paths : [];
+      let copied = 0;
+      for (const pattern of paths) {
+        // Very simple glob: expand ** to recursive copy.
+        const base = pattern.split('**')[0].replace(/\/$/, '');
+        const srcDir = path.join(PROJECT_ROOT, base);
+        if (!fs.existsSync(srcDir)) continue;
+        // Recursive copy of .md files
+        function walk(dir) {
+          for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, e.name);
+            if (e.isDirectory()) { walk(full); continue; }
+            if (!e.isFile()) continue;
+            if (!full.endsWith('.md')) continue;
+            const rel = path.relative(srcDir, full);
+            const out = path.join(destPath, rel);
+            fs.mkdirSync(path.dirname(out), { recursive: true });
+            fs.copyFileSync(full, out);
+            copied++;
+          }
+        }
+        walk(srcDir);
+      }
+      report.pulled.push({ name: s.name, kind: 'self', files: copied });
+      continue;
+    }
+
+    // External git source — use sparse checkout into a tmp dir then copy.
+    const { execSync } = require('child_process');
+    const os = require('os');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rihal-brain-'));
+    const branch = s.branch || cfg.defaults?.branch || 'main';
+    try {
+      execSync(
+        `git clone --depth=1 --filter=blob:none --sparse --branch="${branch}" "${repo}" "${tmp}"`,
+        { stdio: 'pipe' }
+      );
+      const paths = Array.isArray(s.paths) ? s.paths : [];
+      execSync(`git -C "${tmp}" sparse-checkout set ${paths.map(p => `"${p}"`).join(' ')}`, { stdio: 'pipe' });
+
+      const destPath = path.join(PROJECT_ROOT, s.dest);
+      fs.mkdirSync(destPath, { recursive: true });
+      // Copy everything the sparse checkout materialized.
+      function copyTree(src, dst) {
+        for (const e of fs.readdirSync(src, { withFileTypes: true })) {
+          if (e.name === '.git') continue;
+          const sp = path.join(src, e.name);
+          const dp = path.join(dst, e.name);
+          if (e.isDirectory()) { fs.mkdirSync(dp, { recursive: true }); copyTree(sp, dp); }
+          else if (e.isFile()) fs.copyFileSync(sp, dp);
+        }
+      }
+      copyTree(tmp, destPath);
+      report.pulled.push({ name: s.name, kind: 'git', repo, branch });
+    } catch (e) {
+      report.errors.push({ name: s.name, error: String(e.message || e).slice(0, 200) });
+    } finally {
+      try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+    }
+  }
+
+  if (report.errors.length) report.ok = false;
+  return report;
+}
+
 function cmdFindFiles(rawArgs) {
   const flags = {};
   const parts = rawArgs.split(/\s+/).filter(p => p);
@@ -2778,6 +3002,10 @@ async function main() {
       case 'verify': {
         const verify = require(path.join(__dirname, 'lib', 'verify.cjs'));
         result = verify.dispatch(PROJECT_ROOT, args);
+        break;
+      }
+      case 'brain': {
+        result = cmdBrain(args);
         break;
       }
       case 'agent-skills':

--- a/rihal/brain/README.md
+++ b/rihal/brain/README.md
@@ -1,0 +1,38 @@
+# rihal/brain — The Rihal Context Layer
+
+This directory is populated on install (and on every `/rihal:update`) by `rihal-tools brain pull`. Its job is simple: pull Rihal's institutional knowledge — PR/commit/issue standards, architecture decisions, internal guides — into every Rihalian's project so their AI assistant already knows how Rihal builds.
+
+## Structure
+
+```
+rihal/brain/
+├── sources.yaml           # upstream repo configuration (see below)
+├── rihal-github/          # PR/commit/issue standards from the Rihal GitHub org
+├── rihal-docs/            # architecture, guides, playbooks from the Rihal docs repo
+└── best-practices/        # in-repo best practices, pulled from rihal/skills/_shared/
+```
+
+## Sources
+
+Content is pulled from three kinds of source:
+
+1. **External Rihal repos** — GitHub org + docs repo. URLs are placeholders until M5 / issue #162 lands with the real addresses. Once filled, `brain pull` uses `git` sparse-checkout to fetch only the paths listed in `sources.yaml`.
+2. **Self** — the special `repo: self` entry points back at this repo, so in-tree best-practices land under `rihal/brain/best-practices/` on every install.
+3. **Cached** — fetched content is cached locally with a short TTL (configurable per source, default 6h). `brain pull` respects the cache; pass `--fresh` to force a re-clone.
+
+## Update policy
+
+- Local edits to any file under `rihal/brain/` are **overwritten** on every `/rihal:update`. Rihal Code treats the upstream sources as the single source of truth. If the Rihal standard needs to change, the change happens upstream — then every Rihalian benefits.
+- Per-invocation: `node .rihal/bin/rihal-tools.cjs brain pull`.
+- Per project: runs automatically as part of `npx rihal-code install`.
+
+## Privacy
+
+If any source is private, `brain pull` uses the user's `gh auth` token (set `defaults.private: true` in `sources.yaml`). If `gh auth status` fails, the pull skips that source with a clear message instead of hanging.
+
+## Status — v2.0
+
+- `sources.yaml` is scaffolded with placeholder URLs.
+- `brain pull` subcommand is wired in `rihal/bin/rihal-tools.cjs`.
+- Real URLs arrive with issue #162 (M5).
+- Live MCP replacement lands in v3.0 (issue #163 / design doc at `docs/adr/mcp-design.md`).

--- a/rihal/brain/best-practices/no-autonomous-bypass.md
+++ b/rihal/brain/best-practices/no-autonomous-bypass.md
@@ -1,0 +1,37 @@
+# No Autonomous-Mode Bypass
+
+This fragment is referenced by every step-file workflow that enforces halt-at-menu. Do not inline its contents into individual step files — reference this file so the rule stays single-sourced.
+
+## The Rule
+
+Step-file skills (`rihal-create-prd`, `rihal-sprint-planning`, `rihal-create-epics-and-stories`, etc.) halt at every menu and wait for user input. **This is invariant.** The agent MUST NOT invent an "autonomous mode", "research mode", or any other self-declared bypass that skips discovery questions.
+
+Phrases like *"just write it autonomously"*, *"create the full thing ready to execute"*, *"skip the questions"*, or *"use research mode"* from the user are **not** authorization to bypass halt. They are signals that the user wants the skill to move efficiently — answer by running the next step's questions compactly, not by skipping them.
+
+## The Only Sanctioned Bypass Paths
+
+There are exactly two ways to legitimately run a skill without halting at menus:
+
+1. **Project-wide:** `.rihal/config.yaml` → `mode: yolo`. The config loader flags `yoloMode=true` in the runtime context; step files check this flag and may auto-advance.
+2. **Per-invocation:** `/rihal:do --auto <question>` on the router. The router sets `autoMode=true` and passes it to the dispatched skill.
+
+If **neither** flag is set, halt is mandatory regardless of what the user's prompt text says.
+
+## Required Behavior When Asked to Bypass Without a Flag
+
+1. Acknowledge the user's intent in one sentence.
+2. Show the current step's menu anyway.
+3. Tell the user the two sanctioned paths (config flag or `--auto`) if they want fully hands-off execution.
+4. Do not generate any output artifact (PRD, sprint plan, roadmap, etc.) until the user either selects a menu option or sets one of the sanctioned flags.
+
+## Anti-Example (What NOT to Do)
+
+> User: *"use rihal research skills and create best PRD ready to execute"*
+>
+> ❌ Agent: *"Switching to autonomous mode — researching the domain and drafting a complete execution-ready PRD."* *(then writes full PRD)*
+
+That response invents a mode that does not exist and violates the halt invariant.
+
+## Correct Response
+
+> ✅ Agent: *"I hear you want the PRD written end-to-end. The halt rule applies unless you set `mode: yolo` in `.rihal/config.yaml` or re-invoke via `/rihal:do --auto`. Here is the step-01 menu — pick Continue and I will drive each step concisely."*

--- a/rihal/brain/best-practices/research-citation-rule.md
+++ b/rihal/brain/best-practices/research-citation-rule.md
@@ -1,0 +1,39 @@
+# Research & Citation Rule
+
+Referenced by any step-file workflow that writes content derived from external sources (competitor pricing, API tiers, market sizing, benchmark numbers, vendor claims, etc.).
+
+## The Rule
+
+If an output artifact (PRD, research note, architecture doc, roadmap) contains a specific external claim — a price, a percentage, a named competitor feature, an API limit — then **every such claim must be traceable to a `WebFetch` (or equivalent document-fetch) call made in the same session**. `WebSearch` snippets alone are not sufficient evidence because snippets are paraphrased and may be stale.
+
+## What This Means in Practice
+
+Before writing a claim like *"Competitor X costs $12.50/mo"*:
+
+1. Run `WebFetch` on the source URL (not just `WebSearch` for a snippet).
+2. Quote the exact sentence from the fetched content in your internal reasoning.
+3. Include the URL in the citations block of the artifact.
+4. If the URL is paywalled, login-walled, or returns a different claim than expected, drop the number — do not paraphrase from memory or search-result previews.
+
+## The Trap to Avoid
+
+Observed failure pattern (rihal-code session, social-poster-x PRD generation):
+
+- Agent ran two `WebSearch` calls.
+- Agent wrote a PRD citing four specific URLs with specific dollar amounts.
+- Agent never ran `WebFetch` on any of the four URLs.
+- Numbers may be accurate-looking hallucinations.
+
+This pattern is forbidden. A citation block without `WebFetch` evidence is a lie to the reader.
+
+## If the User Is Running Autonomously
+
+`mode: yolo` and `/rihal:do --auto` bypass halt-at-menu, but they do **not** bypass this rule. A fully-autonomous run still has to fetch every cited URL before writing the claim.
+
+## Checklist Before Writing a Citation
+
+- [ ] `WebFetch` was called on this URL in this session.
+- [ ] The fetched content contains the specific number / claim being cited.
+- [ ] The claim in the artifact matches the fetched content verbatim (or is a clearly labeled summary).
+
+If any box is unchecked: remove the claim, replace with *"(needs source)"*, and flag to the user.

--- a/rihal/brain/best-practices/state-sync-rule.md
+++ b/rihal/brain/best-practices/state-sync-rule.md
@@ -1,0 +1,43 @@
+# State Sync Rule
+
+Referenced by skills that write `ROADMAP.md`, `epics.md`, or sprint artifacts. These artifacts are not authoritative on their own — downstream workflows (`/rihal:status`, `/rihal:progress`, `/rihal:execute`) read `.rihal/state.json`. If you write a planning artifact and skip state sync, the project ends up with two divergent pictures.
+
+## The Rule
+
+Immediately after appending content to any of:
+
+- `.planning/ROADMAP.md` — milestones and phases
+- `.planning/epics.md` — epics and stories
+- `.rihal/phases/{phase}/sprint-{N}.md` — sprint commitments
+
+Call the state-sync helper:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+or, for a more targeted write, use the JSON-API helpers exposed by `rihal-tools.cjs`:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state upsert-milestone <json>
+node .rihal/bin/rihal-tools.cjs state upsert-phase <json>
+node .rihal/bin/rihal-tools.cjs state upsert-epic <json>
+```
+
+If `rihal-tools.cjs` does not yet expose the needed subcommand, fall back to `state sync --from-disk` which re-parses `ROADMAP.md` + `epics.md` and rebuilds the relevant sections of `state.json`.
+
+## Verification After Sync
+
+- `node .rihal/bin/rihal-tools.cjs state read` returns a phase count that matches the phase table in `ROADMAP.md`.
+- `/rihal:status` and `/rihal:progress`, run back-to-back, agree on the current milestone name and phase count.
+
+## Why This Matters
+
+Observed failure (rihal-code, social-poster-x install, Apr 2026):
+
+- User ran `/rihal:create-epics-and-stories`.
+- `ROADMAP.md` gained 10 phases; `epics.md` gained 62 stories.
+- `.rihal/state.json` remained at the initial bootstrap with 1 phase.
+- `/rihal:status` showed 1 phase; `/rihal:progress` showed 10.
+
+That divergence is what this rule exists to prevent.

--- a/rihal/brain/sources.yaml
+++ b/rihal/brain/sources.yaml
@@ -1,0 +1,59 @@
+# Rihal Brain — content sources
+#
+# This file lists upstream repositories whose content is pulled into
+# rihal/brain/ on install and on every `/rihal:update`. Anything pulled
+# here ends up in every Rihalian's project context.
+#
+# Repo URLs are placeholders until M5 (issue #162) when Hanzla supplies
+# the real Rihal GitHub org and docs repo addresses. `brain pull` will
+# detect `<PLACEHOLDER>` entries and skip them with a clear message.
+#
+# Real URLs land as part of issue #162. Until then, this file documents
+# the intent and shape of the pipeline.
+
+version: 1
+
+defaults:
+  # Branch to track when no per-source override is set.
+  branch: main
+  # How long before a cached checkout is considered stale and re-cloned.
+  cache_ttl: 6h
+  # Private repos — if true, `brain pull` uses the user's `gh auth` token.
+  # Set to false for public repos (faster, no auth needed).
+  private: true
+
+sources:
+  - name: rihal-github-standards
+    description: >
+      PR, issue, and commit standards for the Rihal GitHub org. Every
+      Rihalian's AI sees these when reviewing or drafting a PR.
+    repo: "<PLACEHOLDER: github.com/rihal-om/???>"
+    branch: main
+    paths:
+      - docs/pr-standards.md
+      - docs/issue-standards.md
+      - docs/commit-standards.md
+      - docs/review-checklist.md
+    dest: rihal/brain/rihal-github/
+
+  - name: rihal-docs
+    description: >
+      Architecture decisions, internal guides, role playbooks. The bulk
+      of the Rihal institutional knowledge lives here.
+    repo: "<PLACEHOLDER: github.com/rihal-om/???>"
+    branch: main
+    paths:
+      - "architecture/**/*.md"
+      - "guides/**/*.md"
+      - "standards/**/*.md"
+      - "playbooks/**/*.md"
+    dest: rihal/brain/rihal-docs/
+
+  - name: rihal-best-practices
+    description: >
+      Hanzla's one-year-of-usage best practices — in-repo, version-
+      controlled alongside the rest of Rihal Code.
+    repo: self
+    paths:
+      - rihal/skills/_shared/**/*.md
+    dest: rihal/brain/best-practices/

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-02-outcomes.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-02-outcomes.md
@@ -1,0 +1,64 @@
+# Step 2: Extract Major Outcomes from PRD
+
+**Progress: Step 2 of 10** — Next: Milestone Sequencing
+
+## STEP GOAL
+
+Parse the approved PRD, extract every named outcome / success metric / scope item, and present them back to the user for confirmation. No grouping into milestones yet — that's step 3.
+
+## MANDATORY RULES
+
+- 🛑 Do NOT invent outcomes not present in the PRD.
+- 🛑 Do NOT skip outcomes you consider "obvious". The user decides what matters.
+- ⏸️ HALT at the A/P/C menu at the end of this step.
+- 🚷 No autonomous bypass — see `../../../_shared/no-autonomous-bypass.md`.
+
+## SEQUENCE
+
+### 1. Re-read the PRD
+
+Load `{inputFile}` (`{planning_artifacts}/prd.md`). Focus on:
+
+- **Scope** section — every in-scope feature.
+- **Success Metrics** / **Goals** — the numbers the product is measured against.
+- **Out of scope** — goes to Backlog in step 7, but note it now so we don't accidentally promote later.
+
+### 2. Build the outcome list
+
+For each outcome, capture:
+
+| Field | Example |
+|-------|---------|
+| ID | O-01 |
+| Name | "Paid subscription tier live" |
+| Source | "PRD §3 Scope, line 12" |
+| Acceptance hint | "Stripe integrated, ≥ 3 paid customers" |
+| Dependencies | O-02 (auth must ship first) |
+
+Order by PRD order — the user can reorder in step 3.
+
+### 3. Present for confirmation
+
+Show a compact table:
+
+```
+Outcomes extracted from PRD ({count}):
+
+  O-01  Paid subscription tier live            (PRD §3)
+  O-02  User authentication                    (PRD §3)
+  O-03  Team workspaces                        (PRD §4)
+  ...
+
+[A] Accept — these are the outcomes, proceed to sequencing
+[P] Propose — I want to add / remove / rename outcomes
+[C] Continue to step 3 (same as A)
+```
+
+If user picks `P`, re-open the extraction with user-supplied additions / removals, re-present until user picks A or C.
+
+### 4. Persist & advance
+
+On A or C:
+- Append the outcomes table to `{outputFile}` under a `## Outcomes (extracted from PRD)` heading.
+- Update frontmatter: add `step-02-outcomes` to `stepsCompleted`.
+- Load `./step-03-sequencing.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-03-sequencing.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-03-sequencing.md
@@ -1,0 +1,65 @@
+# Step 3: Sequence Outcomes into Milestones
+
+**Progress: Step 3 of 10** — Next: Assign Date Windows
+
+## STEP GOAL
+
+Group the outcome list from step 2 into coherent milestones (M1, M2, M3, ...) and agree the cut lines with the user.
+
+## MANDATORY RULES
+
+- ⏸️ HALT at menu; every milestone grouping is user-confirmed.
+- 🛑 Maximum 6 active milestones per roadmap. If the user insists on more, split into v1/v2 and stop at M6 for v1.
+- 🛑 Every milestone MUST have at least 2 outcomes. A single-outcome milestone is a phase, not a milestone — suggest merging.
+
+## SEQUENCE
+
+### 1. Propose an initial grouping
+
+Based on outcome dependencies and natural clusters (same surface area, same user persona, same delivery cadence):
+
+```
+Proposed milestones:
+
+M1 — MVP (foundation)
+  O-02  User authentication
+  O-04  Basic project CRUD
+  O-07  Single-tenant data model
+
+M2 — Team collaboration
+  O-03  Team workspaces
+  O-05  Roles & permissions
+  O-09  Activity feed
+
+M3 — Monetization
+  O-01  Paid subscription tier
+  O-06  Usage metering
+  O-08  Billing portal
+
+[A] Accept this grouping
+[P] Propose changes (move, split, merge)
+[C] Continue to step 4
+```
+
+### 2. Explain your reasoning
+
+One sentence per milestone:
+- M1 is the tech foundation — everything else depends on it.
+- M2 turns a single-user tool into a team tool.
+- M3 lets Rihal charge money — depends on stable M1 + M2.
+
+### 3. Handle user proposals
+
+If user picks `P`, ask what to change:
+- Move O-X from M_Y to M_Z
+- Split M_X into two milestones
+- Merge M_X + M_Y
+- Rename milestone
+
+Re-present the updated grouping until user picks A or C.
+
+### 4. Persist & advance
+
+- Append the confirmed grouping to `{outputFile}` under `## Milestones (proposed)` heading.
+- Update `stepsCompleted`.
+- Load `./step-04-windows.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-04-windows.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-04-windows.md
@@ -1,0 +1,60 @@
+# Step 4: Assign Date Windows
+
+**Progress: Step 4 of 10** — Next: Kill Criteria
+
+## STEP GOAL
+
+Give each milestone a start / end date. Verify realism with the user using rough capacity math.
+
+## MANDATORY RULES
+
+- 🛑 NEVER invent velocity numbers. If the PRD has "target launch" dates, use those. If not, ASK.
+- 🛑 Windows must not overlap unless the user explicitly says parallel tracks exist.
+- ⏸️ HALT at menu.
+
+## SEQUENCE
+
+### 1. Establish capacity
+
+If the PRD specifies team size / target launch, use those. Otherwise ask:
+
+```
+To size these milestones realistically:
+1. How many devs will work on this? (default: 1)
+2. When is the target launch for M1?
+3. Any hard external deadlines (client commit, event, regulatory)?
+```
+
+Do NOT proceed until numeric answers are on the table (unless `mode: yolo` or `--auto` — see `../../../_shared/no-autonomous-bypass.md`).
+
+### 2. Propose windows
+
+Simple rule of thumb: 6–10 weeks per milestone for a 1–2 person team, 4–6 weeks for a 3–5 person team. Adjust based on outcome complexity from step 2.
+
+```
+Proposed windows:
+
+M1 — MVP                    {start}  →  {start + 8 weeks}  (2026-04-24 → 2026-06-19)
+M2 — Team collaboration    (M1 end) →  +6 weeks           (2026-06-19 → 2026-07-31)
+M3 — Monetization          (M2 end) →  +6 weeks           (2026-07-31 → 2026-09-11)
+
+Total: ~20 weeks / 5 months.
+
+[A] Accept windows
+[P] Propose changes (shift, compress, extend)
+[C] Continue to step 5
+```
+
+### 3. Realism check
+
+Before accepting, briefly call out risks:
+- "M1 at 8 weeks with 1 dev is tight — auth alone is often 3-4 weeks."
+- "M3 monetization after only 14 weeks of combined M1+M2 assumes no pivots on pricing."
+
+The user decides. You surface the risk; you do not refuse the window.
+
+### 4. Persist & advance
+
+- Append windows to each milestone block in `{outputFile}`.
+- Update `stepsCompleted`.
+- Load `./step-05-kill-criteria.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-05-kill-criteria.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-05-kill-criteria.md
@@ -1,0 +1,59 @@
+# Step 5: Binary Kill Criteria
+
+**Progress: Step 5 of 10** — Next: Phase Stubs
+
+## STEP GOAL
+
+For each milestone, define **binary** kill criteria — numeric thresholds that, if breached, trigger a pivot or sunset.
+
+## MANDATORY RULES
+
+- 🛑 Kill criteria must be binary (number + threshold), not adjectival.
+  - ❌ "Low user satisfaction"
+  - ✅ "NPS < 10 at 90 days post-launch"
+- 🛑 Every milestone gets at least one kill criterion.
+- 🛑 Every criterion cites a source — PRD success metric, Rihal standard, or user-provided number.
+
+## SEQUENCE
+
+### 1. Extract candidates from PRD
+
+From `{inputFile}`'s Success Metrics section, flag any that naturally invert into kill criteria:
+
+| Success metric | Natural kill criterion |
+|---|---|
+| ≥ 300 paid users in 90 days | MRR < $1,200 at 90 days |
+| ≥ 40% D7 retention | D7 retention < 15% |
+| ≥ 99.5% post-success rate | Success rate < 97% |
+
+### 2. Assign to milestones
+
+Match each kill criterion to the milestone whose outcomes it measures. If a metric is meaningful only post-M3 (e.g. MRR), it applies to M3's kill criterion.
+
+### 3. Propose
+
+```
+Kill criteria (binary — two or more firing = pivot review):
+
+M1 — MVP
+  K1.1  Auth success rate < 99% at 2 weeks post-launch
+  K1.2  Launch slips > 3 weeks past 2026-06-19
+
+M2 — Team collaboration
+  K2.1  < 30% of M1 users activate workspace feature
+  K2.2  Workspace-creation error rate > 1%
+
+M3 — Monetization
+  K3.1  MRR < $1,200 at 90 days
+  K3.2  Paid → churn within 30 days > 25%
+
+[A] Accept
+[P] Propose (add/remove/adjust thresholds)
+[C] Continue
+```
+
+### 4. Persist & advance
+
+- Append criteria to each milestone in `{outputFile}`.
+- Update `stepsCompleted`.
+- Load `./step-06-phase-stubs.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-06-phase-stubs.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-06-phase-stubs.md
@@ -1,0 +1,56 @@
+# Step 6: Phase Stubs Under Each Milestone
+
+**Progress: Step 6 of 10** — Next: Backlog parking lot
+
+## STEP GOAL
+
+For each milestone, list the phases it contains as **stubs** (number + name + one-line goal). No plan detail — phases get full plans via `/rihal:plan` later.
+
+## MANDATORY RULES
+
+- 🛑 Phase numbers follow Rihal's NN convention (01, 02, ..., 99, then 999.x for parking lot).
+- 🛑 Do NOT generate plan content here. That's `/rihal:plan-phase`.
+- 🛑 Each phase has one-sentence goal, max.
+- ⏸️ HALT at menu.
+
+## SEQUENCE
+
+### 1. Propose phase stubs
+
+Mirror the outcome-to-milestone mapping from step 3. Each outcome typically becomes 1–2 phases; a milestone typically has 3–6 phases.
+
+```
+Phase stubs:
+
+M1 — MVP (Apr 24 → Jun 19)
+  01  Setup & scaffolding — repo, CI, Vercel, Neon provisioned
+  02  Auth — email/password + Google OAuth
+  03  Project CRUD — list, detail, create, archive
+  04  Data model hardening — migrations, seeds, indexes
+
+M2 — Team collaboration (Jun 19 → Jul 31)
+  05  Workspace model — users-in-workspaces
+  06  Roles & permissions — admin/member/viewer
+  07  Activity feed — who did what, when
+
+M3 — Monetization (Jul 31 → Sep 11)
+  08  Stripe integration — checkout + portal
+  09  Usage metering — event ingestion + aggregation
+  10  Billing UI — plans, invoices, receipts
+
+[A] Accept
+[P] Propose changes (add, remove, rename, renumber)
+[C] Continue
+```
+
+### 2. Cross-check against outcomes
+
+Every outcome from step 2 must be covered by at least one phase stub. If an outcome is uncovered, flag it:
+
+> ⚠ O-11 "Admin audit log" does not appear in any phase. Add to M2 (phase 07)? Move to backlog? Drop?
+
+### 3. Persist & advance
+
+- Append phase stubs to each milestone block in `{outputFile}`.
+- Update `stepsCompleted`.
+- Load `./step-07-backlog.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-07-backlog.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-07-backlog.md
@@ -1,0 +1,44 @@
+# Step 7: Backlog Parking Lot
+
+**Progress: Step 7 of 10** — Next: Write ROADMAP.md
+
+## STEP GOAL
+
+Capture everything that is **not** in M1..Mn but was considered. Use Rihal's `999.x` parking-lot convention so items can be promoted later via `/rihal:plant-seed` or `/rihal:review-backlog`.
+
+## MANDATORY RULES
+
+- 🛑 Pull explicit "Out of scope" items from the PRD into the backlog — do not silently drop them.
+- 🛑 Each backlog item gets a one-line reason ("deferred: needs user auth from M1").
+- ⏸️ HALT at menu.
+
+## SEQUENCE
+
+### 1. Collect backlog items
+
+Sources:
+- PRD's explicit "Out of scope" section.
+- Outcomes that got cut in step 3 sequencing.
+- Ideas raised during step 4-6 that did not make it into a milestone.
+
+### 2. Number using 999.x convention
+
+```
+Backlog (999.x — promotable with /rihal:plant-seed):
+
+  999.1  Cross-post to LinkedIn          — deferred: requires LinkedIn OAuth (M2+)
+  999.2  Auto-DM feature                 — deferred: abuse risk, needs rate-limit design
+  999.3  Mobile native app               — deferred: PWA sufficient for launch
+  999.4  Enterprise SSO                  — deferred: no enterprise customers yet
+  999.5  Audit log export                — deferred: nice-to-have for M2
+
+[A] Accept
+[P] Add, remove, re-number
+[C] Continue
+```
+
+### 3. Persist & advance
+
+- Append backlog section to `{outputFile}`.
+- Update `stepsCompleted`.
+- Load `./step-08-write-roadmap.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-08-write-roadmap.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-08-write-roadmap.md
@@ -1,0 +1,58 @@
+# Step 8: Write Final ROADMAP.md
+
+**Progress: Step 8 of 10** — Next: State Sync
+
+## STEP GOAL
+
+Assemble everything collected in steps 2–7 into a clean, publication-quality ROADMAP.md. This is the document the user will reference, share, and revisit.
+
+## MANDATORY RULES
+
+- 🛑 Use the canonical ROADMAP.md structure (mirrors `docs/ROADMAP.md` pattern in Rihal Code itself).
+- 🛑 Every milestone: name, window, goal, outcomes, phases, kill criteria.
+- 🛑 Every phase stub: number, name, one-line goal.
+- 🛑 Clean markdown — no debug sections, no "proposed" labels, no step headings.
+
+## SEQUENCE
+
+### 1. Template for each milestone block
+
+```markdown
+## Milestone M{N} — {Name}
+
+**Window:** {start} → {end}
+**Goal:** {one-sentence goal}
+**Status:** {Planned | Active | Complete}
+
+### Outcomes
+- O-{nn} {Outcome name} (PRD §{section})
+
+### Phases
+| # | Name | Goal |
+|---|------|------|
+| {NN} | {phase-name} | {one-line goal} |
+
+### Acceptance
+{1–3 bullet acceptance criteria derived from outcomes}
+
+### Kill criteria (binary)
+- K{N}.{M}: {criterion with numeric threshold}
+
+---
+```
+
+### 2. Assemble
+
+- Top of file: title (project name + "Roadmap"), source PRD reference, hard deadline if any.
+- Then all milestones in order.
+- Then `## Backlog (parking lot)` section with 999.x items.
+- Then a brief `## Kill criteria summary` reminder explaining binary-threshold semantics.
+
+### 3. Overwrite {outputFile}
+
+Replace the step-by-step accumulated content with the clean final version. Do NOT keep the intermediate "proposed" sections. The frontmatter stays and is updated.
+
+### 4. Persist & advance
+
+- Update frontmatter: `stepsCompleted` adds `step-08-write-roadmap`. Add `totalMilestones`, `totalPhases`, `hardDeadline` (if any).
+- Load `./step-09-state-sync.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-09-state-sync.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-09-state-sync.md
@@ -1,0 +1,62 @@
+# Step 9: Sync ROADMAP into state.json
+
+**Progress: Step 9 of 10** — Next: Completion summary
+
+## STEP GOAL
+
+Call the state-sync CLI so `.rihal/state.json` reflects every milestone and phase we just wrote to `ROADMAP.md`. This closes the drift loophole documented in issue #126 and enforced by `_shared/state-sync-rule.md`.
+
+## MANDATORY RULES
+
+- 🛑 This step MUST run. Skipping it leaves `/rihal:status` and `/rihal:progress` showing stale data.
+- 🛑 Report the sync result (pulled phases, existing phases updated, any errors) to the user.
+
+## SEQUENCE
+
+### 1. Run the sync
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+### 2. Parse and report
+
+Expected JSON output shape:
+
+```json
+{
+  "ok": true,
+  "synced": true,
+  "milestones_found": 3,
+  "phases_found": 10,
+  "phases_upserted": 10,
+  "epics_found": 0,
+  "roadmap_exists": true,
+  "epics_exists": false
+}
+```
+
+Report to the user:
+
+```
+State sync complete:
+  Milestones:       3
+  Phases:          10
+  Phases upserted: 10 (new)
+  Epics:            0 (none yet — run /rihal:create-epics-and-stories next)
+```
+
+### 3. Verify drift closed
+
+Run a sanity check:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state read | grep -E '"phases":|"name":'
+```
+
+Confirm the phase count matches what ROADMAP.md shows. If not, surface a warning and tell the user to run `state sync --from-disk` again or check for markdown malformation.
+
+### 4. Advance
+
+- Update `stepsCompleted`: add `step-09-state-sync`.
+- Load `./step-10-complete.md`.

--- a/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-10-complete.md
+++ b/rihal/skills/actions/2-plan/rihal-create-milestone/steps/step-10-complete.md
@@ -1,0 +1,56 @@
+# Step 10: Completion Summary & Handoff
+
+**Progress: Step 10 of 10** — Final step
+
+## STEP GOAL
+
+Summarize what was produced, mark the workflow complete in frontmatter, and point the user at the next natural command.
+
+## SEQUENCE
+
+### 1. Final frontmatter update
+
+Append `step-10-complete` to `stepsCompleted`. Add `completedAt: {ISO date}`.
+
+### 2. Completion summary to user
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ RIHAL ► ROADMAP CREATED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Source PRD:     {inputFile}
+Roadmap:        {outputFile}
+State:          .rihal/state.json (synced)
+
+Shipped:
+  {N} milestones: M1..M{N}
+  {M} phases:     01..{NN}
+  {K} backlog items: 999.1..999.{K}
+
+Hard deadline:  {deadline or "none specified"}
+
+[{completedAt}]
+```
+
+### 3. Next-step menu (intent-based, mirrors the GSD /progress Route A/B/C pattern)
+
+```
+What's next?
+
+  [A] Decompose M1 into epics + stories
+      → /rihal:create-epics-and-stories
+
+  [B] Plan the first phase in detail
+      → /rihal:plan-phase 01
+
+  [C] Review the roadmap with the team
+      → /rihal:council "Is this roadmap realistic?"
+
+  [D] Park and review later
+      → Roadmap is saved; pick up with /rihal:progress anytime
+```
+
+### 4. HALT
+
+This is the terminal step. Do NOT load another step file. The workflow is complete.

--- a/rihal/workflows/update.md
+++ b/rihal/workflows/update.md
@@ -135,7 +135,22 @@ If the command exits with non-zero status, print:
 ```
 Exit with error code.
 
-## Step 8 — Success summary
+## Step 8 — Pull Rihal brain content (v2.0)
+
+After installer finishes, refresh the brain content from configured sources (issue #158). This is idempotent and safe to re-run.
+
+```bash
+node .rihal/bin/rihal-tools.cjs brain pull
+```
+
+Parse the JSON output. Report counts to the user:
+- `pulled[]` — sources actually fetched (git or in-repo)
+- `skipped[]` — sources with `<PLACEHOLDER>` URLs (waiting on issue #162 / M5)
+- `errors[]` — sources that failed (network, auth, etc.)
+
+If the user passed a version argument (`/rihal:update v1.3.0`), pass it through to `brain pull` as `--version v1.3.0`. When supported, `brain pull` will pin each source to the commit recorded in that release's `sources.yaml`. Unknown versions: treat as latest and warn.
+
+## Step 9 — Success summary
 
 Print:
 
@@ -146,6 +161,8 @@ Updated files: N
   - file-path-1
   - file-path-2
   ...
+
+Rihal brain: M sources pulled, K skipped (placeholder URLs)
 
 New version available at: .rihal/
 


### PR DESCRIPTION
## Summary

Ships v2.0 "Rihal Brain" — repositioning + full ingestion + ownership + release pipeline + MCP ADR + completed create-milestone skill.

Closes:
- #134 step files for rihal-create-milestone
- #157 M1 repositioning
- #158 M2 brain ingestion
- #160 M3 role ownership (partial — deep folder reorg deferred to v2.1)
- #161 M4 release pipeline (workflow ready; v2.0.0 tag is manual step)
- #163 M6 MCP design ADR (v3 roadmap)

Out of scope (separate PRs / later):
- #159 M2.5 progress/status UX (GSD-parity) — too large for this PR
- #162 M5 real Rihal URLs — blocked on Hanzla
- #135, #136, #137 — orphans from earlier fix branch; unrelated to v2.0

## Commits

| Area | Commit |
|------|--------|
| docs: new narrative docs | `78572a6` |
| docs: README top + CHANGELOG | `9b6bff2` |
| feat: brain ingestion | `c157a87` |
| feat: CODEOWNERS + CONTRIBUTING | `83e613e` |
| feat: release.yml | `85ef63d` |
| docs: MCP ADR 0003 | `253dc36` |
| feat: create-milestone steps | (pushed just now) |

## Verification

- `node -c rihal/bin/rihal-tools.cjs` — OK
- `node rihal/bin/rihal-tools.cjs brain list` — returns 3 sources, 2 placeholder
- `node rihal/bin/rihal-tools.cjs brain pull` — skips placeholders, copies 3 in-repo best-practice files to `rihal/brain/best-practices/`
- Compliance check passes (all SKILL.md have Output Format + Examples)
- New files only for README/CHANGELOG changes — no collisions with parallel agent work

## Next steps after merge

1. Tag `v2.0.0` → release.yml auto-publishes GitHub Release with bundle.
2. Supply Rihal GitHub org + docs repo URLs → close #162.
3. Schedule v2.1 to do the deep skill-folder reorganization under role directories.
4. Queue M2.5 (#159) for next iteration.