### PR TITLE
feat(v2.5): GSD-parity /progress and /status rebuild

### DIFF
--- a/docs/parking-lot-convention.md
+++ b/docs/parking-lot-convention.md
@@ -1,0 +1,83 @@
+# The 999.x Parking-Lot Convention
+
+**TL;DR:** Use phase numbers `999.1`, `999.2`, `999.3`, ... for backlog items that have a concrete name but no committed window yet. Promote to a real phase number (e.g. `07`) when the team decides to schedule them.
+
+---
+
+## Why
+
+Every project accumulates ideas that are too shaped to live in a Notion backlog but too unscheduled to occupy real phase numbers. Without a convention, those ideas either:
+
+- Clog the roadmap with ambiguous "future" entries.
+- Get lost in scattered Slack threads.
+- Become phase 73 when the team wanted 73 to be something else.
+
+The `999.x` convention fixes all three: parking-lot items have real numeric identity (so you can reference `999.5` in a PR), but `999.x` is unambiguously not part of any active milestone.
+
+---
+
+## Usage
+
+### Capturing a parking-lot item
+
+Use `/rihal:plant-seed` — it writes into ROADMAP.md under the parking-lot section AND appends to `state.phases[]` with `status: parking-lot`.
+
+```
+Backlog (999.x — promotable with /rihal:state promote-backlog):
+
+  999.1  Cross-post to LinkedIn         — deferred: requires LinkedIn OAuth
+  999.2  Auto-DM feature                — deferred: abuse risk
+  999.3  Mobile native app              — deferred: PWA sufficient for launch
+  999.4  Enterprise SSO                 — deferred: no enterprise customers yet
+  999.5  Audit log export               — deferred: nice-to-have for M2
+```
+
+### Promoting one to a scheduled phase
+
+When the team commits to building a parking-lot item, run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state promote-backlog 999.5 --to 07
+```
+
+This:
+- Updates `state.phases[]` — moves the entry from `999.5` to `07`, records `promoted_from: 999.5` and `promoted_at: <timestamp>` for audit.
+- Renames the on-disk `.planning/phases/999.5-audit-log-export/` directory to `07-audit-log-export/` if it exists.
+- Does **not** touch ROADMAP.md — you still edit that manually to move the item out of the Backlog section into the right milestone. (The CLI does one thing well; roadmap prose is yours to write.)
+
+### Listing current parking-lot items
+
+```bash
+node .rihal/bin/rihal-tools.cjs state read | python3 -c "
+import sys, json
+for p in json.load(sys.stdin).get('state', {}).get('phases', []):
+    if str(p.get('number', '')).startswith('999.'):
+        print(p['number'], '—', p.get('name', ''))
+"
+```
+
+Or, simpler: `/rihal:progress` includes parking-lot items in its phase listing, labelled as parking-lot when their number matches `999.x`.
+
+---
+
+## Numbering rules
+
+- Parking-lot items use decimal sub-numbering: `999.1`, `999.2`, ..., `999.99`. No gaps needed — increment by 1.
+- When promoting, pick any available integer phase number (`07`, `12`, `73`). Do not reuse `999.5` for a new parking-lot item after it's been promoted; allocate `999.6` next.
+- Decimal sub-numbering is also available for **urgent insertion** (e.g. `07.1` slotted between `07` and `08`) — see `/rihal:insert-phase` for that flow. Different tool, same numeric grammar.
+
+---
+
+## Why not a separate `backlog.yaml`?
+
+Because parking-lot items become active phases. Keeping them in the same data structure means:
+
+- Zero migration when we promote (`promoted_from` is just metadata).
+- `/rihal:progress` sees everything in one pass — no separate loader.
+- CODEOWNERS rules, reviews, and audit flows work on parking-lot items out of the box.
+
+---
+
+## Inspiration
+
+This convention is adopted from the GSD (Get Shit Done) sibling project, which uses `999.1`, `999.5` etc. for promotable backlog phases and has proven durable across dozens of GSD projects over a year of use.

--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -1947,6 +1947,57 @@ function cmdState(subArgs) {
     return { updated: true, status: 'reset', preserved_decisions: preserved.decisions.length };
   }
 
+  // --- promote-backlog <from> --to <target> ---
+  // Promote a 999.x parking-lot phase to a real phase number.
+  // Mutates state.phases[]; renames the on-disk directory if present.
+  // Tracks issue #159 (M2.5 — GSD-parity 999.x convention).
+  if (sub === 'promote-backlog') {
+    const from = subArgs[1];
+    const flags = parseFlags(2);
+    const to = flags.to;
+    if (!from || !to) {
+      throw new Error('Usage: state promote-backlog <999.x> --to <NN>');
+    }
+    if (!/^999\.\d+$/.test(from)) {
+      throw new Error(`Source must be 999.x parking-lot number, got: ${from}`);
+    }
+    if (!/^\d{1,3}(\.\d+)?$/.test(to)) {
+      throw new Error(`Target must be NN or NN.M, got: ${to}`);
+    }
+    const state = readState() || defaultState();
+    if (!state.phases) state.phases = [];
+    const idx = state.phases.findIndex(p => String(p.number) === from);
+    if (idx < 0) {
+      throw new Error(`Parking-lot phase ${from} not found in state.phases`);
+    }
+    if (state.phases.some(p => String(p.number) === to)) {
+      throw new Error(`Target phase ${to} already exists`);
+    }
+    const phase = state.phases[idx];
+    const oldNumber = phase.number;
+    phase.number = to;
+    phase.promoted_from = oldNumber;
+    phase.promoted_at = new Date().toISOString();
+
+    // Rename on-disk directory if present
+    const phasesDir = path.join(PLANNING_DIR, 'phases');
+    let renamed = false;
+    if (fs.existsSync(phasesDir)) {
+      for (const entry of fs.readdirSync(phasesDir)) {
+        if (entry.startsWith(`${oldNumber}-`) || entry === oldNumber) {
+          const oldPath = path.join(phasesDir, entry);
+          const newPath = path.join(phasesDir, entry.replace(oldNumber, to));
+          fs.renameSync(oldPath, newPath);
+          renamed = true;
+          break;
+        }
+      }
+    }
+
+    writeState(state);
+    return { ok: true, promoted: { from: oldNumber, to }, renamed_disk: renamed };
+  }
+
   // --- sync --from-disk ---
   // Parse ROADMAP.md + epics.md and upsert milestones/phases/epics into state.json.
   // Preserves existing statuses on matching phase names/numbers.
@@ -2025,7 +2076,7 @@ function cmdState(subArgs) {
     return { ok: true, synced: true, ...parsed };
   }
 
-  throw new Error(`Unknown state subcommand: ${sub}.\nCommon: read, set-phase, advance-plan, add-decision, decisions-global, add-blocker, sync\nRun 'rihal-tools.cjs help' for the full list of state subcommands.`);
+  throw new Error(`Unknown state subcommand: ${sub}.\nCommon: read, set-phase, advance-plan, add-decision, decisions-global, add-blocker, sync, promote-backlog\nRun 'rihal-tools.cjs help' for the full list of state subcommands.`);
 }
 
 /**
@@ -2866,6 +2917,293 @@ function cmdBrain(args) {
   return report;
 }
 
+/**
+ * cmdProgress — single pre-computed progress blob (GSD-parity, issue #159).
+ *
+ * Subcommands:
+ *   progress init          Full snapshot — everything /rihal:progress needs.
+ *   progress bar --raw     ASCII bar only (e.g. "[████░░░░] 50%").
+ *   progress insights      insights[] array (drift warnings, between-milestone detection).
+ *   progress routes        intent-tree routes[] for Next Up menu.
+ *
+ * Pushing logic into the CLI lets the workflow file shrink to pure
+ * rendering — no ROADMAP.md parsing, no SUMMARY.md walking, no grep.
+ */
+function cmdProgress(args) {
+  const sub = args[0] || 'init';
+  const rawMode = args.includes('--raw');
+
+  // Resolve paths — workflow files may run this from any subdirectory.
+  const statePath = path.join(RIHAL_DIR, 'state.json');
+  const roadmapPath = path.join(PLANNING_DIR, 'ROADMAP.md');
+  const phasesDir = path.join(PLANNING_DIR, 'phases');
+
+  function readState() {
+    if (!fs.existsSync(statePath)) return null;
+    try { return JSON.parse(fs.readFileSync(statePath, 'utf8')); }
+    catch { return null; }
+  }
+
+  function parseRoadmapPhases() {
+    if (!fs.existsSync(roadmapPath)) return [];
+    const text = fs.readFileSync(roadmapPath, 'utf8');
+    const phases = [];
+    const rowRe = /^\|\s*(\d{1,3}(?:\.\d+)?)\s*\|\s*([^|]+?)\s*\|\s*([^|]*?)\s*\|/gm;
+    let m;
+    while ((m = rowRe.exec(text)) !== null) {
+      const num = m[1].trim();
+      const name = m[2].trim();
+      const goal = m[3].trim();
+      if (!/^\d/.test(num)) continue;
+      if (name.toLowerCase() === 'phase') continue;
+      phases.push({ number: num, name, goal });
+    }
+    return phases;
+  }
+
+  function extractMilestoneName() {
+    if (!fs.existsSync(roadmapPath)) return null;
+    const text = fs.readFileSync(roadmapPath, 'utf8');
+    const m = text.match(/^##\s+Milestone\s+(M\d+\S*)\s*[—\-:]?\s*(.*)$/m);
+    return m ? `${m[1]} ${m[2]}`.trim() : null;
+  }
+
+  function walkPhaseDirs() {
+    if (!fs.existsSync(phasesDir)) return {};
+    const byNum = {};
+    for (const entry of fs.readdirSync(phasesDir)) {
+      const full = path.join(phasesDir, entry);
+      if (!fs.statSync(full).isDirectory()) continue;
+      const numMatch = entry.match(/^(\d{1,3}(?:\.\d+)?)/);
+      if (!numMatch) continue;
+      const num = numMatch[1];
+      const files = fs.readdirSync(full);
+      byNum[num] = {
+        path: full,
+        dirName: entry,
+        plan_count: files.filter(f => /PLAN\.md$|-PLAN\.md$|SPRINT\.md$/.test(f)).length,
+        summary_count: files.filter(f => /SUMMARY\.md$|-SUMMARY\.md$/.test(f)).length,
+        has_research: files.includes('RESEARCH.md'),
+        has_context: files.includes('CONTEXT.md'),
+        has_verification: files.includes('VERIFICATION.md'),
+      };
+    }
+    return byNum;
+  }
+
+  function detectInsights(state, roadmapPhases, diskByNum) {
+    const insights = [];
+    const statePhases = (state && (state.state?.phases || state.phases)) || [];
+
+    // Drift: ROADMAP phase count vs state.json phase count
+    if (roadmapPhases.length > 0 && statePhases.length !== roadmapPhases.length) {
+      insights.push({
+        kind: 'drift',
+        severity: 'warn',
+        message: `ROADMAP.md has ${roadmapPhases.length} phases, state.json has ${statePhases.length}. Run: node .rihal/bin/rihal-tools.cjs state sync --from-disk`,
+      });
+    }
+
+    // Undercount: phases that exist on disk but not in state
+    const statePhaseNums = new Set(statePhases.map(p => String(p.number)));
+    const diskPhaseNums = Object.keys(diskByNum);
+    const missingFromState = diskPhaseNums.filter(n => !statePhaseNums.has(n));
+    if (missingFromState.length > 0) {
+      insights.push({
+        kind: 'undercount',
+        severity: 'warn',
+        message: `${missingFromState.length} phase dir(s) on disk not registered in state.json: ${missingFromState.slice(0, 5).join(', ')}`,
+      });
+    }
+
+    // Between-milestones heuristic: no current_phase + previous milestone's last phase is complete
+    if (state && state.current_phase === null && statePhases.length > 0) {
+      const allComplete = statePhases.every(p => p.status === 'complete' || p.completed);
+      if (allComplete) {
+        insights.push({
+          kind: 'between-milestones',
+          severity: 'info',
+          message: 'All registered phases complete — effectively between milestones. Consider /rihal:audit-milestone or /rihal:new-milestone.',
+        });
+      }
+    }
+
+    return insights;
+  }
+
+  function deriveRoutes(state, roadmapPhases, diskByNum) {
+    const routes = [];
+    const statePhases = (state && (state.state?.phases || state.phases)) || [];
+
+    // Route A — phases with pending plans (ready to execute)
+    const pendingExec = statePhases.filter(p => {
+      const disk = diskByNum[String(p.number)];
+      return disk && disk.plan_count > disk.summary_count;
+    }).slice(0, 3);
+    for (const p of pendingExec) {
+      routes.push({
+        letter: 'A',
+        label: `Execute phase ${p.number} — unfinished plans`,
+        command: `/rihal:execute-phase ${p.number}`,
+      });
+    }
+
+    // Route B — phases with research but no plans
+    const researchOnly = Object.entries(diskByNum)
+      .filter(([num, d]) => d.has_research && d.plan_count === 0)
+      .slice(0, 3);
+    for (const [num, d] of researchOnly) {
+      routes.push({
+        letter: 'B',
+        label: `Plan phase ${num} — researched, awaiting plan`,
+        command: `/rihal:plan-phase ${num}`,
+      });
+    }
+
+    // Route C — close out milestone if everything seems done
+    const allDone = statePhases.length > 0 && statePhases.every(p => p.status === 'complete' || p.completed);
+    if (allDone) {
+      routes.push({ letter: 'C', label: 'Audit current milestone', command: '/rihal:audit-milestone' });
+      routes.push({ letter: 'C', label: 'Complete current milestone', command: '/rihal:complete-milestone' });
+    }
+
+    // Fallback — nothing obvious: offer status
+    if (routes.length === 0) {
+      routes.push({ letter: 'A', label: 'Check progress detail', command: '/rihal:progress' });
+      routes.push({ letter: 'B', label: 'Start a council on what to do next', command: '/rihal:council' });
+    }
+
+    return routes;
+  }
+
+  function buildBar(completed, total) {
+    if (!total) return '[░░░░░░░░░░░░░░░░░░░░] 0/0 (0%)';
+    const pct = Math.round((completed / total) * 100);
+    const width = 20;
+    const filled = Math.min(width, Math.round((completed / total) * width));
+    const bar = '█'.repeat(filled) + '░'.repeat(width - filled);
+    return `[${bar}] ${completed}/${total} (${pct}%)`;
+  }
+
+  // Build the core snapshot once — all subcommands derive from it.
+  const state = readState();
+  const roadmapPhases = parseRoadmapPhases();
+  const diskByNum = walkPhaseDirs();
+  const statePhases = (state && (state.state?.phases || state.phases)) || [];
+  const completedCount = statePhases.filter(p => p.status === 'complete' || p.completed).length;
+  const phaseCount = Math.max(statePhases.length, roadmapPhases.length);
+
+  if (sub === 'bar') {
+    const bar = buildBar(completedCount, phaseCount);
+    if (rawMode) { console.log(bar); process.exit(0); }
+    return { ok: true, bar, completed: completedCount, total: phaseCount };
+  }
+
+  if (sub === 'insights') {
+    return { ok: true, insights: detectInsights(state, roadmapPhases, diskByNum) };
+  }
+
+  if (sub === 'routes') {
+    return { ok: true, routes: deriveRoutes(state, roadmapPhases, diskByNum) };
+  }
+
+  // sub === 'init' (default) — full snapshot
+  const currentPhase = state && state.current_phase;
+  const insights = detectInsights(state, roadmapPhases, diskByNum);
+  const routes = deriveRoutes(state, roadmapPhases, diskByNum);
+
+  return {
+    ok: true,
+    project: state && state.project,
+    milestone: extractMilestoneName(),
+    current_phase: currentPhase,
+    phase_count: phaseCount,
+    completed_count: completedCount,
+    bar: buildBar(completedCount, phaseCount),
+    phases: roadmapPhases.map(p => ({
+      ...p,
+      disk: diskByNum[p.number] || null,
+      in_state: statePhases.some(sp => String(sp.number) === p.number),
+    })),
+    decisions: state ? (state.decisions || []).slice(-3) : [],
+    blockers: state ? (state.blockers || []).filter(b => !b.resolved).slice(0, 5) : [],
+    insights,
+    routes,
+    updated: state && state.updated,
+  };
+}
+
+/**
+ * cmdSummaryExtract — surgically pull named fields from a SUMMARY.md.
+ * Avoids whole-file loads when the caller only wants one or two headings.
+ * Usage: summary-extract <path> --fields one_liner,status
+ */
+function cmdSummaryExtract(args) {
+  const filePath = args[0];
+  const fieldsFlag = args.indexOf('--fields');
+  const fields = fieldsFlag >= 0 ? (args[fieldsFlag + 1] || '').split(',').map(s => s.trim()).filter(Boolean) : ['one_liner'];
+
+  if (!filePath) return { ok: false, error: 'Usage: summary-extract <path> [--fields a,b,c]' };
+  if (!fs.existsSync(filePath)) return { ok: false, error: `file not found: ${filePath}` };
+
+  const text = fs.readFileSync(filePath, 'utf8');
+  const out = { ok: true, path: filePath };
+
+  const fieldToPatterns = {
+    one_liner: [/^##\s+One[-\s]?liner\s*\n([\s\S]*?)(?=\n##|\n---|$)/im, /^##\s+Summary\s*\n([\s\S]*?)(?=\n##|\n---|$)/im],
+    status: [/^##\s+Status\s*\n([\s\S]*?)(?=\n##|\n---|$)/im, /^status:\s*(.+)$/im],
+    outcomes: [/^##\s+Outcomes?\s*\n([\s\S]*?)(?=\n##|\n---|$)/im],
+    decisions: [/^##\s+Decisions?\s*\n([\s\S]*?)(?=\n##|\n---|$)/im],
+    blockers: [/^##\s+Blockers?\s*\n([\s\S]*?)(?=\n##|\n---|$)/im],
+    followups: [/^##\s+Follow[-\s]?ups?\s*\n([\s\S]*?)(?=\n##|\n---|$)/im, /^##\s+Next[-\s]?steps?\s*\n([\s\S]*?)(?=\n##|\n---|$)/im],
+  };
+
+  for (const f of fields) {
+    const patterns = fieldToPatterns[f] || [new RegExp(`^##\\s+${f.replace(/_/g, '[ _-]?')}\\s*\\n([\\s\\S]*?)(?=\\n##|\\n---|$)`, 'im')];
+    let value = null;
+    for (const re of patterns) {
+      const m = text.match(re);
+      if (m && m[1]) { value = m[1].trim().split('\n').map(l => l.trim()).filter(Boolean).join('\n'); break; }
+    }
+    // Fallback for one_liner: first non-empty paragraph after H1
+    if (f === 'one_liner' && !value) {
+      const afterH1 = text.replace(/^#[^\n]*\n/, '');
+      const firstPara = afterH1.match(/^[^\n#][^\n]*(?:\n(?!\n)[^\n#][^\n]*)*/m);
+      if (firstPara) value = firstPara[0].trim();
+    }
+    out[f] = value;
+  }
+
+  return out;
+}
+
+/**
+ * cmdStateSnapshot — compact, display-friendly state extract.
+ * Hides internal machinery (lock metadata, full history) from callers
+ * that only need a render-ready summary.
+ */
+function cmdStateSnapshot() {
+  const statePath = path.join(RIHAL_DIR, 'state.json');
+  if (!fs.existsSync(statePath)) return { ok: true, state: null };
+  let state;
+  try { state = JSON.parse(fs.readFileSync(statePath, 'utf8')); }
+  catch (e) { return { ok: false, error: `invalid state.json: ${e.message}` }; }
+
+  return {
+    ok: true,
+    project: state.project,
+    current_phase: state.current_phase,
+    current_plan: state.current_plan,
+    current_sprint: state.current_sprint,
+    phase_count: (state.phases || []).length,
+    decisions_count: (state.decisions || []).length,
+    blockers_open: (state.blockers || []).filter(b => !b.resolved).length,
+    last_session: state.last_session,
+    updated: state.updated,
+    active_workstream: state.active_workstream,
+  };
+}
+
 function cmdFindFiles(rawArgs) {
   const flags = {};
   const parts = rawArgs.split(/\s+/).filter(p => p);
@@ -3006,6 +3344,18 @@ async function main() {
       }
       case 'brain': {
         result = cmdBrain(args);
+        break;
+      }
+      case 'progress': {
+        result = cmdProgress(args);
+        break;
+      }
+      case 'summary-extract': {
+        result = cmdSummaryExtract(args);
+        break;
+      }
+      case 'state-snapshot': {
+        result = cmdStateSnapshot();
         break;
       }
       case 'agent-skills':

--- a/rihal/workflows/progress.md
+++ b/rihal/workflows/progress.md
@@ -1,19 +1,18 @@
 <purpose>
-Check project progress, summarize recent work and what's ahead, then intelligently route to the next action — either executing an existing plan or creating the next one. Provides situational awareness before continuing work.
+Render project progress: what was accomplished, where you are, what's pending, what's next. All data comes from a single `rihal-tools progress init` call. This workflow is a pure renderer — no direct markdown parsing, no state.json grep, no phase-directory walk.
 
-For a quick board view use `/rihal:sprint-status`. This gives the full narrative + routing.
+**SSOT:** `.rihal/state.json`, surfaced through `rihal-tools progress init`. `/rihal:progress` and `/rihal:status` call the same CLI and cannot disagree (issue #131 closed).
 
-**SSOT:** `.rihal/state.json` is the single source of truth for phase counts and current position. `/rihal:progress` and `/rihal:status` MUST agree. When this workflow reads `ROADMAP.md` for human-readable goal text, it must first verify that `state.json` is in sync — if not, surface a drift warning and suggest `node .rihal/bin/rihal-tools.cjs state sync --from-disk`. See issue #131.
+For a sprint-board view, use `/rihal:sprint-status`. For a concise dashboard, use `/rihal:status`. This workflow gives the full narrative view with recent-work excerpts and an intent-tree Next Up menu.
 </purpose>
 
 <required_reading>
 @.rihal/references/output-format.md
-
 Read all files referenced by the invoking prompt's execution_context before starting.
 </required_reading>
 
 <output_format>
-Print a progress header using banner format from output-format.md:
+Banner from output-format.md:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -21,8 +20,8 @@ Print a progress header using banner format from output-format.md:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Use status symbols (✓ complete, ◆ in_progress, ○ planned) throughout.
-End with a Next Up block (see output-format.md) when a routing suggestion applies.
+Use ✓ complete / ◆ in_progress / ○ planned / 🅿 parking-lot throughout.
+End with a Next Up block rendered from the CLI's `routes[]` array.
 </output_format>
 
 <process>
@@ -31,30 +30,15 @@ End with a Next Up block (see output-format.md) when a routing suggestion applie
 
 ## 1. Init context
 
-**Load progress context:**
+Fetch the full progress snapshot in a single call:
 
 ```bash
-INIT=$(node .rihal/bin/rihal-tools.cjs init progress 2>/dev/null || node .rihal/bin/rihal-tools.cjs init)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
-STATE=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null || echo '{}')
-
-# Drift check — detect state/disk divergence (issue #131)
-if [ -f .planning/ROADMAP.md ]; then
-  DISK_PHASES=$(grep -cE "^\|\s*[0-9]{1,3}" .planning/ROADMAP.md)
-  STATE_PHASES=$(echo "$STATE" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const s=JSON.parse(d);console.log((s.state?.phases||s.phases||[]).length)}catch{console.log(0)}}")
-  if [ "$DISK_PHASES" -gt 0 ] && [ "$DISK_PHASES" -ne "$STATE_PHASES" ]; then
-    echo "⚠ Drift: ROADMAP.md has $DISK_PHASES phases, state.json has $STATE_PHASES. Run: node .rihal/bin/rihal-tools.cjs state sync --from-disk"
-  fi
-fi
+SNAPSHOT=$(node .rihal/bin/rihal-tools.cjs progress init)
 ```
 
-Extract from init/state JSON: `project_exists`, `roadmap_exists`, `state_exists`, `phases`, `current_phase`, `next_phase`, `milestone_version`, `completed_count`, `phase_count`, `paused_at`, `state_path`, `roadmap_path`, `project_path`, `config_path`.
+Parse as JSON.
 
-```bash
-DISCUSS_MODE=$(node .rihal/bin/rihal-tools.cjs config 2>/dev/null | grep -oE '"discuss_mode"\s*:\s*"[^"]*"' | cut -d'"' -f4 || echo "discuss")
-```
-
-If `project_exists` is false (no `.planning/` directory and no `.rihal/state.json`):
+If `SNAPSHOT.project` is null AND `SNAPSHOT.phases[]` is empty:
 
 ```
 No planning structure found.
@@ -64,510 +48,137 @@ Run /rihal:new-project to start a new project.
 
 Exit.
 
-If missing STATE.md: suggest `/rihal:new-project`.
-
-**If ROADMAP.md missing but PROJECT.md exists:**
-
-This means a milestone was completed and archived. Go to **Route F** (between milestones).
-
-If missing both ROADMAP.md and PROJECT.md: suggest `/rihal:new-project`.
-</step>
-
-<step name="load">
-
-## 2. Load
-
-Use structured extraction — prefer targeted reads over dumping full files:
-
-- `STATE=$(node .rihal/bin/rihal-tools.cjs state read)` — decisions, blockers, current_phase
-- `cat .planning/ROADMAP.md` — phase list
-- Inspect `.planning/phases/*/` for PLAN.md, SPRINT.md, SUMMARY.md presence
-
-This minimizes orchestrator context usage.
-</step>
-
-<step name="analyze_roadmap">
-
-## 3. Analyze roadmap
-
-Parse ROADMAP.md sections into an internal phases array. For each phase, record:
-- number
-- name
-- goal
-- dependencies (from "Depends on" lines if present)
-- `disk_status` — `complete` (SUMMARY.md exists), `partial` (PLAN.md/SPRINT.md exists without SUMMARY.md), `planned` (directory exists, no plan yet), `empty` (directory exists but empty), `no_directory` (not yet scaffolded)
-- plan_count, summary_count
-
-Aggregate: total plans, summaries, progress percent. Identify current and next phase.
-</step>
-
-<step name="recent">
-
-## 4. Recent work
-
-Gather recent work context:
+Read `DISCUSS_MODE` from config (separate cheap call):
 
 ```bash
-# Last 10 commits
-git log --oneline -10 2>/dev/null
-
-# 2-3 most recent SUMMARY.md files
-(find .planning/phases -name "SUMMARY.md" -o -name "*-SUMMARY.md" 2>/dev/null) | xargs -r ls -t 2>/dev/null | head -3
+DISCUSS_MODE=$(node .rihal/bin/rihal-tools.cjs config 2>/dev/null | grep -oE '"discuss_mode"\s*:\s*"[^"]*"' | cut -d'"' -f4 || echo "discuss")
 ```
 
-Read the 2-3 most recent SUMMARY.md files. Extract the first one-liner line (often under a `## One-liner` or `## Summary` heading, or the first non-empty paragraph after the H1). This shows "what we've been working on".
 </step>
 
-<step name="position">
+<step name="recent_work">
 
-## 5. Position
+## 2. Recent work excerpts
 
-Parse current position from init context and roadmap analysis:
+For the last 2-3 phase directories with SUMMARY.md, pull the one-liner field surgically:
 
-- Use `current_phase` and `next_phase` from the parsed roadmap
-- Note `paused_at` if work was paused (from `$STATE`)
-- Count pending todos: `node .rihal/bin/rihal-tools.cjs state read | grep -c '"status":"pending"' 2>/dev/null || echo 0`
-- Check for active debug sessions: `(ls .planning/debug/*.md 2>/dev/null || true) | grep -v resolved | wc -l`
+```bash
+# find the 3 most recent SUMMARY.md files
+(find .planning/phases -name "SUMMARY.md" -o -name "*-SUMMARY.md" 2>/dev/null) | xargs -r ls -t 2>/dev/null | head -3 | while read f; do
+  node .rihal/bin/rihal-tools.cjs summary-extract "$f" --fields one_liner,status
+done
+```
+
+Each call returns `{ ok: true, one_liner: "...", status: "..." }`. Collect into an in-memory list for rendering. This avoids loading full SUMMARY.md bodies — context-expensive and unnecessary.
+
+</step>
+
+<step name="insights">
+
+## 3. Insights — surface what the CLI noticed
+
+`SNAPSHOT.insights[]` contains drift warnings, between-milestone detection, phase-dir undercount. Render above the progress bar so the user sees divergences immediately:
+
+```
+⚠ {insight.message}     (severity: warn)
+ℹ {insight.message}     (severity: info)
+```
+
+Each insight that mentions a fix command should have it surfaced exactly as-is — e.g. "Run: node .rihal/bin/rihal-tools.cjs state sync --from-disk".
+
 </step>
 
 <step name="report">
 
-## 6. Report
-
-Generate a simple text progress bar (e.g., `[████░░░░] 50%`) where filled is proportional to `completed_count / phase_count`.
-
-Present:
+## 4. Render the progress view
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  RIHAL ► PROGRESS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-# [Project Name]
+# {SNAPSHOT.project}
 
-**Progress:** [████░░░░] {completed_count}/{phase_count} phases
-**Profile:** [quality/balanced/budget/inherit]
+{insights block — printed FIRST if present}
+
+**Progress:** {SNAPSHOT.bar}
+**Milestone:** {SNAPSHOT.milestone or "—"}
 **Discuss mode:** {DISCUSS_MODE}
 
 ## Recent Work
-- [Phase X, Plan Y]: [what was accomplished - 1 line from SUMMARY.md]
-- [Phase X, Plan Z]: [what was accomplished]
+- [Phase {N}]: {one_liner extracted in step 2}
+- [Phase {N}]: {one_liner}
 
 ## Current Position
-Phase [N] of [total]: [phase-name]
-Plan [M] of [phase-total]: [status]
-CONTEXT: [✓ if CONTEXT.md exists | - if not]
+Phase [{SNAPSHOT.current_phase}] of [{SNAPSHOT.phase_count}]
+Plan progress: {completed_count}/{phase_count}
 
-## Key Decisions Made
-- [extract from $STATE.decisions[]]
+## Key Decisions
+- {SNAPSHOT.decisions[].summary} — [{phase}.{plan}], {date}
 
-## Blockers/Concerns
-- [extract from $STATE.blockers[]]
+## Blockers
+- ⚠ {SNAPSHOT.blockers[].description} — [{phase}.{plan}]
 
 ## Pending Todos
-- [count] pending — /rihal:check-todos to review
+- {todo count} pending — /rihal:check-todos to review
+(Skip if count = 0)
 
 ## Active Debug Sessions
-- [count] active — /rihal:debug to continue
-(Only show this section if count > 0)
-
-## What's Next
-[Next phase/plan objective from roadmap analysis]
+- {count} active — /rihal:debug to continue
+(Skip if count = 0)
 ```
+
+Omit any section whose underlying array is empty — don't print "Key Decisions" with zero entries.
 
 </step>
 
-<step name="route">
+<step name="next_up">
 
-## 7. Route
+## 5. Next Up — intent tree
 
-Determine next action based on verified counts.
-
-**Step 1: Count plans, summaries, and UAT in current phase**
-
-List files in the current phase directory:
-
-```bash
-CUR_DIR=".planning/phases/[current-phase-dir]"
-(ls -1 ${CUR_DIR}/*-PLAN.md ${CUR_DIR}/PLAN.md ${CUR_DIR}/SPRINT.md 2>/dev/null || true) | wc -l
-(ls -1 ${CUR_DIR}/*-SUMMARY.md ${CUR_DIR}/SUMMARY.md 2>/dev/null || true) | wc -l
-(ls -1 ${CUR_DIR}/*-UAT.md ${CUR_DIR}/UAT.md 2>/dev/null || true) | wc -l
-```
-
-State: "This phase has {X} plans, {Y} summaries."
-
-**Step 1.5: Check for unaddressed UAT gaps**
-
-```bash
-grep -l "status: diagnosed\|status: partial" ${CUR_DIR}/*-UAT.md ${CUR_DIR}/UAT.md 2>/dev/null || true
-```
-
-Track:
-- `uat_with_gaps`: UAT.md files with status "diagnosed" (gaps need fixing)
-- `uat_partial`: UAT.md files with status "partial" (incomplete testing)
-
-**Step 1.6: Cross-phase health check**
-
-Since rihal-tools does not expose `audit-uat --raw`, do a quick scan:
-
-```bash
-OUTSTANDING_UAT=$(grep -rl "status: diagnosed\|status: partial\|status: pending\|status: blocked\|status: skipped\|status: human_needed" .planning/phases/*/UAT*.md .planning/phases/*/*-UAT.md 2>/dev/null | wc -l)
-```
-
-Track: `outstanding_debt` — count of files with outstanding verification items.
-
-**If outstanding_debt > 0:** Add a warning section to the progress report output (in the `report` step), placed between "## What's Next" and the route suggestion:
-
-```markdown
-## Verification Debt ({N} files across prior phases)
-
-| Phase | File | Issue |
-|-------|------|-------|
-| {phase} | {filename} | {pending_count} pending, {skipped_count} skipped, {blocked_count} blocked |
-| {phase} | {filename} | human_needed — {count} items |
-
-Review: `/rihal:audit-uat` — full cross-phase audit
-Resume testing: `/rihal:verify-work {phase}` — retest specific phase
-```
-
-This is a WARNING, not a blocker — routing proceeds normally.
-
-**Step 2: Route based on counts**
-
-| Condition | Meaning | Action |
-|-----------|---------|--------|
-| uat_partial > 0 | UAT testing incomplete | Go to **Route E.2** |
-| uat_with_gaps > 0 | UAT gaps need fix plans | Go to **Route E** |
-| paused_at set | Work was paused | Go to **Route Paused** |
-| summaries < plans | Unexecuted plans exist | Go to **Route A** |
-| summaries = plans AND plans > 0 | Phase complete | Go to Step 3 |
-| plans = 0 | Phase not yet planned | Go to **Route B** |
-
----
-
-**Route A: Unexecuted plan exists**
-
-Find the first PLAN.md or SPRINT.md without matching SUMMARY.md.
-Read its `<objective>` or goal section.
+Render `SNAPSHOT.routes[]` as a grouped menu. Group by `letter` field (A / B / C). Multiple routes per letter print indented under that letter's heading:
 
 ```
----
+▶ Next Up
 
-## ▶ Next Up
+  [A] Execute unfinished work
+      → /rihal:execute-phase 999.5
+      → /rihal:execute-phase 66
 
-**{phase}-{plan}: [Plan Name]** — [objective summary from PLAN.md]
+  [B] Plan researched-but-unplanned phases
+      → /rihal:plan-phase 68
 
-`/clear` then:
-
-`/rihal:execute {phase}`
-
----
-
-**Also available:**
-- `/rihal:sprint-status` — detailed sprint board
-- `/rihal:next` — auto-advance (zero friction)
+  [C] Close out current milestone
+      → /rihal:audit-milestone
+      → /rihal:complete-milestone
 ```
 
----
+The CLI derives routes from current disk state (researched-not-planned phases, phases with pending plans, all-complete detection for milestone closure). Do NOT second-guess by walking disk yourself.
 
-**Route B: Phase needs planning**
-
-Check if `{phase_num}-CONTEXT.md` or `CONTEXT.md` exists in phase directory.
-
-Check if current phase has UI indicators:
-
-```bash
-PHASE_SECTION=$(sed -n "/^## Phase ${CURRENT_PHASE}/,/^## Phase /p" .planning/ROADMAP.md)
-PHASE_HAS_UI=$(echo "$PHASE_SECTION" | grep -qiE "UI hint.*yes|UI|interface|frontend|component|layout|page|screen|dashboard" && echo "true" || echo "false")
-```
-
-**If CONTEXT.md exists:**
+If `SNAPSHOT.routes[]` is empty or only has fallback entries, print:
 
 ```
----
+▶ Nothing obvious on deck.
 
-## ▶ Next Up
-
-**Phase {N}: {Name}** — {Goal from ROADMAP.md}
-<sub>✓ Context gathered, ready to plan</sub>
-
-`/clear` then:
-
-`/rihal:plan {phase-number}`
-
----
+  [A] /rihal:progress          — refresh
+  [B] /rihal:council            — start a conversation on what next
+  [C] /rihal:new-milestone     — if the current cycle is done
 ```
 
-**If CONTEXT.md does NOT exist AND phase has UI:**
-
-```
----
-
-## ▶ Next Up
-
-**Phase {N}: {Name}** — {Goal from ROADMAP.md}
-
-`/clear` then:
-
-`/rihal:discuss-phase {phase}` — gather context and clarify approach
-
----
-
-**Also available:**
-- `/rihal:ui-phase {phase}` — generate UI design contract (recommended for frontend phases)
-- `/rihal:plan {phase}` — skip discussion, plan directly
-
----
-```
-
-**If CONTEXT.md does NOT exist AND phase has no UI:**
-
-```
----
-
-## ▶ Next Up
-
-**Phase {N}: {Name}** — {Goal from ROADMAP.md}
-
-`/clear` then:
-
-`/rihal:discuss-phase {phase}` — gather context and clarify approach
-
----
-
-**Also available:**
-- `/rihal:plan {phase}` — skip discussion, plan directly
-
----
-```
-
----
-
-**Route E: UAT gaps need fix plans**
-
-UAT.md exists with gaps (diagnosed issues). User needs to plan fixes.
-
-```
----
-
-## ⚠ UAT Gaps Found
-
-**{phase_num}-UAT.md** has {N} gaps requiring fixes.
-
-`/clear` then:
-
-`/rihal:plan {phase} --gaps`
-
----
-
-**Also available:**
-- `/rihal:execute {phase}` — execute phase plans
-- `/rihal:verify-work {phase}` — run more UAT testing
-
----
-```
-
----
-
-**Route E.2: UAT testing incomplete (partial)**
-
-UAT.md exists with `status: partial` — testing session ended before all items resolved.
-
-```
----
-
-## Incomplete UAT Testing
-
-**{phase_num}-UAT.md** has {N} unresolved tests (pending, blocked, or skipped).
-
-`/clear` then:
-
-`/rihal:verify-work {phase}` — resume testing from where you left off
-
----
-
-**Also available:**
-- `/rihal:audit-uat` — full cross-phase UAT audit
-- `/rihal:execute {phase}` — execute phase plans
-
----
-```
-
----
-
-**Route Paused**
-
-State shows `paused_at`:
-
-```
----
-
-## Paused
-
-Work was paused at phase {N}. Context saved.
-
-`/rihal:resume-work` — restore context and continue
-
----
-```
-
----
-
-**Step 3: Check milestone status (only when phase complete)**
-
-Read ROADMAP.md and identify:
-1. Current phase number
-2. All phase numbers in the current milestone section
-
-State: "Current phase is {X}. Milestone has {N} phases (highest: {Y})."
-
-**Route based on milestone status:**
-
-| Condition | Meaning | Action |
-|-----------|---------|--------|
-| current phase < highest phase | More phases remain | Go to **Route C** |
-| current phase = highest phase | Milestone complete | Go to **Route D** |
-
----
-
-**Route C: Phase complete, more phases remain**
-
-Read ROADMAP.md to get the next phase's name and goal. Check if the next phase has UI indicators:
-
-```bash
-NEXT_PHASE_SECTION=$(sed -n "/^## Phase $((Z+1))/,/^## Phase /p" .planning/ROADMAP.md)
-NEXT_HAS_UI=$(echo "$NEXT_PHASE_SECTION" | grep -qiE "UI hint.*yes|UI|interface|frontend|component|layout|page|screen|dashboard" && echo "true" || echo "false")
-```
-
-**If next phase has UI:**
-
-```
----
-
-## ✓ Phase {Z} Complete
-
-## ▶ Next Up
-
-**Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
-
-`/clear` then:
-
-`/rihal:discuss-phase {Z+1}` — gather context and clarify approach
-
----
-
-**Also available:**
-- `/rihal:ui-phase {Z+1}` — generate UI design contract (recommended for frontend phases)
-- `/rihal:plan {Z+1}` — skip discussion, plan directly
-- `/rihal:verify-work {Z}` — user acceptance test before continuing
-
----
-```
-
-**If next phase has no UI:**
-
-```
----
-
-## ✓ Phase {Z} Complete
-
-## ▶ Next Up
-
-**Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
-
-`/clear` then:
-
-`/rihal:discuss-phase {Z+1}` — gather context and clarify approach
-
----
-
-**Also available:**
-- `/rihal:plan {Z+1}` — skip discussion, plan directly
-- `/rihal:verify-work {Z}` — user acceptance test before continuing
-
----
-```
-
----
-
-**Route D: Milestone complete**
-
-```
----
-
-## 🎉 Milestone Complete
-
-All {N} phases finished!
-
-## ▶ Next Up
-
-**Complete Milestone** — archive and prepare for next
-
-`/clear` then:
-
-`/rihal:complete-milestone`
-
----
-
-**Also available:**
-- `/rihal:audit-milestone` — cross-phase audit before archiving
-- `/rihal:verify-work` — user acceptance test before completing milestone
-
----
-```
-
----
-
-**Route F: Between milestones (ROADMAP.md missing, PROJECT.md exists)**
-
-A milestone was completed and archived. Ready to start the next milestone cycle.
-
-Read MILESTONES.md to find the last completed milestone version.
-
-```
----
-
-## ✓ Milestone v{X.Y} Complete
-
-Ready to plan the next milestone.
-
-## ▶ Next Up
-
-**Start Next Milestone** — questioning → research → requirements → roadmap
-
-`/clear` then:
-
-`/rihal:new-milestone`
-
----
-```
-
-</step>
-
-<step name="edge_cases">
-
-## 8. Edge cases
-
-- Phase complete but next phase not planned → offer `/rihal:plan [next]`
-- All work complete → offer milestone completion
-- Blockers present → highlight before offering to continue
-- Handoff file exists (`.rihal/HANDOFF.json` or `.continue-here.md`) → mention it, offer `/rihal:resume-work`
-- Sprint is active with stories remaining → offer `/rihal:execute` with SPRINT.md path
-- No SPRINT.md yet for current phase → offer `/rihal:sprint-planning --phase {N}`
 </step>
 
 </process>
 
-<success_criteria>
+## Success Criteria
 
-- [ ] Rich context provided (recent work, decisions, issues)
-- [ ] Current position clear with visual progress
-- [ ] What's next clearly explained
-- [ ] Smart routing: /rihal:execute if plans exist, /rihal:plan if not, /rihal:discuss-phase if no CONTEXT.md
-- [ ] User confirms before any action
-- [ ] Seamless handoff to appropriate /rihal: command
-- [ ] Paused state surfaced with /rihal:resume-work
-- [ ] UAT gaps surfaced with /rihal:plan --gaps or /rihal:verify-work
-- [ ] Cross-phase verification debt surfaced as a warning (non-blocking)
-- [ ] Between-milestone state surfaced with /rihal:new-milestone
-</success_criteria>
+- [ ] `progress init` called once — not repeatedly per section
+- [ ] No direct parsing of ROADMAP.md, epics.md, or SUMMARY.md in the workflow body
+- [ ] Recent work uses `summary-extract --fields one_liner` (surgical read)
+- [ ] Insights section rendered when non-empty
+- [ ] Next Up is a grouped route tree, not a single suggestion
+
+## On Error
+
+- **CLI missing:** "Rihal Code install missing or stale. Run: npx @hanzlahabib/rihal-code install"
+- **CLI returns `ok: false`:** surface the CLI's error verbatim. Do not attempt to compensate — the CLI's failures are the source of truth on what's wrong.
+- **Network-dependent insights:** there should be none. Insights are computed from local state + disk only.

--- a/rihal/workflows/status.md
+++ b/rihal/workflows/status.md
@@ -1,124 +1,116 @@
 # Workflow: rihal:status
 
 <purpose>
-Read `.rihal/state.json` and print a human-readable project status dashboard.
+Render a human-readable project status dashboard. All data comes from a single `rihal-tools progress init` call — this workflow does NOT parse ROADMAP.md, walk SUMMARY.md files, or grep state.json itself. Rendering only. See `rihal-tools.cjs` `cmdProgress` for the source-of-truth logic (issue #159 M2.5).
 
-**SSOT:** `.rihal/state.json` is the single source of truth for phase counts, milestone names, and current position. `/rihal:status` and `/rihal:progress` MUST agree — if `state.json` is out of date relative to `ROADMAP.md` or `epics.md`, that is a sync bug (see issue #126) and should be fixed by running `node .rihal/bin/rihal-tools.cjs state sync --from-disk`, not by reading the markdown files directly from this workflow.
+**SSOT:** `.rihal/state.json`. `/rihal:status` and `/rihal:progress` both call the same CLI so they cannot disagree. If the CLI reports a drift insight, surface it — do not silently compensate.
 </purpose>
 
 <required_reading>
 @.rihal/references/output-format.md
 </required_reading>
 
-<drift_detection>
-Before printing the dashboard, detect state/disk drift:
-
-```bash
-if [ -f .planning/ROADMAP.md ]; then
-  DISK_PHASES=$(grep -cE "^\|\s*[0-9]{1,3}" .planning/ROADMAP.md)
-  STATE_PHASES=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const s=JSON.parse(d);console.log((s.state?.phases||[]).length)}catch{console.log(0)}}")
-  if [ "$DISK_PHASES" -gt 0 ] && [ "$DISK_PHASES" -ne "$STATE_PHASES" ]; then
-    echo "⚠ Drift detected: ROADMAP.md has $DISK_PHASES phases, state.json has $STATE_PHASES."
-    echo "  Run: node .rihal/bin/rihal-tools.cjs state sync --from-disk"
-  fi
-fi
-```
-
-Print this warning above the dashboard if drift is detected. Do NOT silently fall back to reading `ROADMAP.md` — that was the cause of the `/rihal:status` vs `/rihal:progress` disagreement in issue #131.
-</drift_detection>
-
-<output_format>
-Open with banner:
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- RIHAL ► STATUS — {project}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-Use status symbols (✓ complete, ◆ in_progress, ○ planned) in phase/plan list.
-Highlight open blockers with ⚠. End with Next Up block routing to next action.
-</output_format>
-
 <process>
 
-## Step 1 — Read state
+## Step 1 — Fetch the snapshot
 
 ```bash
-node .rihal/bin/rihal-tools.cjs state read
+SNAPSHOT=$(node .rihal/bin/rihal-tools.cjs progress init)
 ```
 
-Parse the JSON output.
+Parse as JSON. If `SNAPSHOT.ok` is not true, print a one-line error and stop.
 
-**If the output contains `"state": null`:** print the following message and stop:
+If `SNAPSHOT.project` is empty and `SNAPSHOT.phases` is empty, print:
 
 ```
 No state found. Run a council session or execute a plan to initialize state.
 ```
 
-## Step 2 — Print dashboard
+Then stop.
 
-Using the parsed state, print a dashboard in this format:
+## Step 2 — Print banner + dashboard
 
 ```
-╭─ Rihal Status — {project} ─────────────────────╮
-│ Phase:    {current_phase or "none started"}          │
-│ Plan:     {current_plan} completed                   │
-│ Updated:  {updated, human-readable: "2 hours ago"}   │
-╰──────────────────────────────────────────────────────╯
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ RIHAL ► STATUS — {SNAPSHOT.project}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+╭─ Rihal Status — {SNAPSHOT.project} ─────────────────────╮
+│ Milestone:  {SNAPSHOT.milestone or "—"}                 │
+│ Phase:      {SNAPSHOT.current_phase or "none started"}  │
+│ Progress:   {SNAPSHOT.bar}                              │
+│ Updated:    {relative_time(SNAPSHOT.updated)}           │
+╰─────────────────────────────────────────────────────────╯
+```
+
+## Step 3 — Phases section
+
+For each entry in `SNAPSHOT.phases[]`:
+
+- `▶` if `phase.number === SNAPSHOT.current_phase`
+- `✓` if `phase.disk.summary_count > 0` AND matches `phase.disk.plan_count` (complete)
+- `◆` if `phase.disk.plan_count > phase.disk.summary_count` (in progress)
+- `○` otherwise (planned)
+
+```
 Phases:
-▶ [01] Initial Setup — complete ✓
-  [01.01] Schema setup — done
-  [01.02] Seed data — in progress (2/3 tasks)
-▷ [02] API Development — pending
-  [02.01] Routes — pending
-
-Recent decisions ({last 3}):
-• {decision summary} — [phase.plan], {date}
-
-Open blockers ({count}):
-⚠ {blocker description} — [phase.plan]
-
-Council sessions ({last 3}):
-• {date} — {question_slug} — Panel: {panel}
-
-Chain runs ({last 3}):
-• {date} — {slug} — {agents}
-
-Workstreams ({active count}):
-▶ {name} (active) — {phase count} phases
-✓ {name} (complete)
-
-Last session: {last_session, human-readable}
+  ▶ [04] Component compaction — in progress (1/3 plans)
+  ✓ [03] Auth hardening — complete
+  ○ [05] Billing rewrite — planned
 ```
 
-**Formatting rules:**
-- Show hierarchical IDs in `[NN]` format for phases and `[NN.MM]` for plans
-- For `updated` and `last_session`, compute a human-readable relative time (e.g. "2 hours ago", "3 days ago", "just now").
-- For decisions and council sessions, show only the last 3 entries (most recent first).
-- For blockers, show only unresolved ones (`resolved === false`).
-- Include phases section showing current status of all phases and their plans
-- Omit any section that has zero entries (e.g. if no decisions, skip "Recent decisions" entirely).
+If a phase number starts with `999.`, render with a `🅿` marker and the label `(parking lot)`.
 
-## Step 3 — Blocker warning
+## Step 4 — Insights (NEW — issue #159)
 
-If there are any open (unresolved) blockers, end with:
+If `SNAPSHOT.insights[]` is non-empty, print above the Next Up section:
 
 ```
-⚠ {n} unresolved blocker(s). Address before proceeding.
+Insights:
+  ⚠ {insight.message}       (for severity: warn)
+  ℹ {insight.message}       (for severity: info)
 ```
+
+Do NOT hide insights. They exist because the CLI noticed something the workflow would otherwise gloss over.
+
+## Step 5 — Recent decisions + blockers
+
+- If `SNAPSHOT.decisions.length > 0`, print the last 3 (most recent first).
+- If `SNAPSHOT.blockers.length > 0`, render each with ⚠ and the blocker description.
+
+Omit a section entirely when its array is empty.
+
+## Step 6 — Next Up (intent-tree)
+
+Render `SNAPSHOT.routes[]` as a Route A/B/C menu:
+
+```
+Next Up:
+
+  [A] {route where letter === "A"}
+      → {route.command}
+
+  [B] {route where letter === "B"}
+      → {route.command}
+
+  [C] {route where letter === "C"}
+      → {route.command}
+```
+
+Group routes by letter. If multiple routes share a letter, list them indented. If there are no routes, print the fallback suggestion from the CLI output.
 
 </process>
 
 ## Success Criteria
 
-- [ ] State is successfully read from `.rihal/state.json`
-- [ ] Dashboard displays all available sections
-- [ ] Phase hierarchy is clear and properly formatted
-- [ ] Relative timestamps are human-readable
-- [ ] Blockers are highlighted if present
+- [ ] State read via `progress init` — no direct ROADMAP.md or SUMMARY.md parsing
+- [ ] Drift insights surfaced if present
+- [ ] Banner + dashboard printed
+- [ ] Phases section shows symbols based on CLI-computed disk state
+- [ ] Next Up is a route tree, not a single suggestion
 
 ## On Error
 
-- **`rihal-tools.cjs` not found:** tell user to run `rihal-code install-v2`.
-- **state.json missing:** handled in Step 1 with the clean "No state found" message.
-- **Invalid state JSON:** report the specific parsing error and suggest manual inspection of state file
+- **CLI not found:** "Rihal Code install missing. Run: npx @hanzlahabib/rihal-code install"
+- **state.json invalid JSON:** report the CLI's exact error string — the CLI already has a clean error shape.
+- **Unexpected shape:** fall back to the banner + "State present but unreadable. Try: node .rihal/bin/rihal-tools.cjs state read"


### PR DESCRIPTION
Closes #159.

## Design principle

**CLI does the thinking, workflow does the rendering.** Every piece of logic currently scattered across \`status.md\` and \`progress.md\` (ROADMAP parsing, SUMMARY walking, state grepping, drift detection) moves into \`rihal-tools.cjs\`. The workflow files become markdown templates that fetch one JSON blob and render it.

Matches the GSD (sibling Get-Shit-Done project) pattern that has proven durable across dozens of projects.

## New CLI subcommands

| Command | Output |
|---------|--------|
| \`progress init\` | Full snapshot: project, milestone, current phase, bar, phases[], decisions, blockers, insights[], routes[], updated |
| \`progress bar --raw\` | Just the ASCII bar string (e.g. \`[████░░░░] 3/5 (60%)\`) |
| \`progress insights\` | insights[] only — drift, undercount, between-milestones |
| \`progress routes\` | routes[] only — intent-tree for Next Up |
| \`summary-extract <path> --fields one_liner,status,outcomes,decisions,blockers,followups\` | Surgical field extraction — no whole-file load |
| \`state-snapshot\` | Compact state for display rendering |
| \`state promote-backlog 999.x --to NN\` | Promote parking-lot phase; upserts state + renames directory |

## Workflow shrinkage

| File | Before | After | Drop |
|------|--------|-------|------|
| \`rihal/workflows/progress.md\` | 573 lines | 184 lines | **68%** |
| \`rihal/workflows/status.md\` | 106 lines | 116 lines | (same — grew slightly to add insights + route tree sections, but no direct parsing) |

Both workflows call the same \`progress init\` — guaranteed consistency. Closes the seam #131 started to patch.

## Insights (new)

Surface drift and between-milestone detection without the workflow needing to know *how* to detect them:

- \`drift\` — ROADMAP phase count != state phase count
- \`undercount\` — phase dirs on disk not registered in state
- \`between-milestones\` — all phases complete, no current_phase set

Each insight carries a severity + actionable message. Workflows render verbatim.

## Route A/B/C Next Up

Three intent buckets:

- A — Execute phases with pending plans
- B — Plan researched-but-unplanned phases
- C — Close out milestone (audit / complete) when everything is done

Fallback routes when nothing obvious is on deck.

## 999.x parking-lot convention

Full docs at \`docs/parking-lot-convention.md\`. Adopted from GSD. One CLI command promotes a backlog item to a scheduled phase AND renames the directory.

## Verification

- \`node -c rihal/bin/rihal-tools.cjs\` — OK
- \`node rihal/bin/rihal-tools.cjs progress init\` — returns snapshot on this repo (3/5 phases complete, shows undercount insight)
- \`node rihal/bin/rihal-tools.cjs progress bar --raw\` — returns ASCII bar cleanly, exits 0
- \`node rihal/bin/rihal-tools.cjs progress routes\` — returns fallback routes
- \`node rihal/bin/rihal-tools.cjs progress insights\` — returns undercount insight
- All SKILL.md compliance checks still pass (no skill touched)

## Not in this PR

- Full skill-folder reorganization (deferred to v2.1).
- Story-level state sync (#135, separate).
- CI is still blocked on repo billing quota (#165) — this PR cannot trigger release.yml.