### PR TITLE
release: @hanzlaa/rcode@2.1.0 — package rename + npm publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ output/
 !.planning/phases/*/
 !.planning/phases/*/SPRINT.md
 !.planning/phases/*/SCOPE.md
+
+# Build artifacts
+dist/
+image.png

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It's not a chatbot. It's a methodology.
 In any project directory:
 
 ```bash
-npx @hanzlahabib/rihal-code install
+npx @hanzlaa/rcode install
 ```
 
 That's it. One unified installer. Pure file shipping, no runtime dependencies. Installs into:
@@ -81,17 +81,17 @@ Detects your project state (fresh / existing-with-no-rihal / returning), asks a 
 ### Install a specific module
 
 ```bash
-npx @hanzlahabib/rihal-code install --module core         # council + quick-sync only
-npx @hanzlahabib/rihal-code install --module execution --force
-npx @hanzlahabib/rihal-code install --module discovery --force
+npx @hanzlaa/rcode install --module core         # council + quick-sync only
+npx @hanzlaa/rcode install --module execution --force
+npx @hanzlaa/rcode install --module discovery --force
 ```
 
 ### Multi-IDE support
 
 ```bash
-npx @hanzlahabib/rihal-code install --ide claude    # default
-npx @hanzlahabib/rihal-code install --ide cursor
-npx @hanzlahabib/rihal-code install --ide gemini
+npx @hanzlaa/rcode install --ide claude    # default
+npx @hanzlaa/rcode install --ide cursor
+npx @hanzlaa/rcode install --ide gemini
 ```
 
 ---

--- a/docs/pre-demo-checklist.md
+++ b/docs/pre-demo-checklist.md
@@ -29,7 +29,7 @@ Once #165 is fixed, `release.yml` will auto-publish. If #165 isn't fixed, publis
 In a clean scratch dir:
 ```bash
 mkdir /tmp/rihal-demo && cd /tmp/rihal-demo
-npx @hanzlahabib/rihal-code@v2.1.0 install
+npx @hanzlaa/rcode@latest install
 ls -la .rihal/ .claude/
 node .rihal/bin/rihal-tools.cjs brain pull
 node .rihal/bin/rihal-tools.cjs progress init | head -30

--- a/docs/what-is-rihal-code.md
+++ b/docs/what-is-rihal-code.md
@@ -27,7 +27,7 @@ Rihal Code fixes that. One install, and the AI now knows. Every session. Every r
 
 ## What you get when you install it
 
-Running `npx rihal-code install` into a project produces:
+Running `npx @hanzlaa/rcode install` into a project produces:
 
 - **55+ phrase-activated skills** (from `/rihal:create-prd` to `/rihal:sprint-planning` to `/rihal:dev-story`) that route your request to the right workflow.
 - **35+ agents** — Rihal's team in AI form: Sadiq for strategy, Waleed for architecture, Hussain for product, Layla for UX, Fatima for QA, and more. Each has a hard scope boundary, so you know which one to talk to.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@hanzlahabib/rihal-code",
-  "version": "1.0.0-beta.0",
-  "description": "Rihal Code — AI engineering methodology with 44 agents, 93 slash commands, 58 phrase-activated skills. Unified install for Claude Code, Cursor, and Gemini.",
+  "name": "@hanzlaa/rcode",
+  "version": "2.1.0",
+  "description": "Rihal Code (rcode) — installable context-brain for Rihalians. 44 agents, 93 slash commands, 58 skills, pullable Rihal standards. Unified install for Claude Code, Cursor, and Gemini.",
   "main": "cli/index.js",
   "bin": {
+    "rcode": "cli/index.js",
     "rihal-code": "cli/index.js"
   },
   "scripts": {


### PR DESCRIPTION
Ships v2.1.0 to npm as \`@hanzlaa/rcode\` — shorter, scoped under the user's personal npm account.

## What changed

- \`package.json\` — name \`@hanzlahabib/rihal-code\` → \`@hanzlaa/rcode\`, version \`1.0.0-beta.0\` → \`2.1.0\`.
- \`bin\` — exposes both \`rcode\` (primary) and \`rihal-code\` (legacy alias), so \`npx @hanzlaa/rcode\` and existing \`npx rihal-code\` calls both work.
- README install command updated.
- docs/pre-demo-checklist and docs/what-is-rihal-code install commands updated.
- \`.gitignore\` — added \`dist/\` and \`image.png\` to keep build artefacts and screenshots out of tracking.

## Published

- **npm:** https://www.npmjs.com/package/@hanzlaa/rcode
- **Version:** 2.1.0
- **Tarball:** https://registry.npmjs.org/@hanzlaa/rcode/-/rcode-2.1.0.tgz
- **Install command:** \`npx @hanzlaa/rcode install\`

## Why not @rihal/code

User does not yet have access to the \`@rihal\` npm organization — that requires Rihal company approval. \`@hanzlaa/rcode\` is the personal-scope fallback. When Rihal approves \`@rihal/\*\`, a follow-up rename PR migrates; \`@hanzlaa/rcode\` gets a deprecation notice pointing at the new name.

## Deferred to follow-up

Remaining \`rihal-code\` command-name references in \`docs/DAILY-USE.md\`, \`docs/TIERS.md\`, \`docs/V2-PREVIEW.md\`, \`CHANGELOG.md\` are left as-is. The \`rihal-code\` bin alias keeps those commands working; a sweep PR can unify them later.

## Verification

- \`npm view @hanzlaa/rcode\` returns 2.1.0, correct tarball, both bin entries.
- \`npm config delete //registry.npmjs.org/:\_authToken\` ran — no publish token left in \~/.npmrc.
- Tag \`v2.1.0\` pushed.

## Action items for Hanzla

- Rotate the npm token you shared in chat — it's written to history and scrollback; generate a fresh one at https://www.npmjs.com/settings/hanzlaa/tokens.