### PR TITLE
docs: install guidelines + bulk rename to @hanzlaa/rcode across user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to Rihal Code are documented here.
 
 ---
 
+## v2.1.0 — First npm publish as @hanzlaa/rcode (2026-04-24)
+
+**Shipping release.** Live on npm at [@hanzlaa/rcode](https://www.npmjs.com/package/@hanzlaa/rcode). Previously only installable by cloning the repo; now available as `npx @hanzlaa/rcode install` from any project anywhere.
+
+Also bundles M2.5 (GSD-parity `/progress` and `/status` rebuild, PR #166) + the orphan fixes (#135 story-level state sync, #136 verification matrix, #137 create-milestone compliance audit, PR #167 + #168).
+
+### Added
+
+- **npm package:** `@hanzlaa/rcode` scoped under the personal `hanzlaa` npm account (pending Rihal org approval for a future `@rihal/code` rename).
+- **Binary aliases:** `rcode` (primary) + `rihal-code` (legacy alias — existing commands keep working).
+- **`docs/install.md`** — dedicated install guide covering flavors (module subsets, IDE options, version pinning), yolo mode, troubleshooting, uninstall.
+- **M2.5 CLI subcommands** (via PR #166):
+  - `rihal-tools progress init` — single pre-computed snapshot for `/rihal:progress` rendering.
+  - `rihal-tools progress bar --raw` — ASCII bar string only.
+  - `rihal-tools progress insights` — drift / undercount / between-milestones detection.
+  - `rihal-tools progress routes` — intent-tree for Route A/B/C Next Up menu.
+  - `rihal-tools summary-extract` — surgical field extraction from SUMMARY.md (no whole-file load).
+  - `rihal-tools state-snapshot` — compact state for display.
+  - `rihal-tools state promote-backlog 999.x --to NN` — parking-lot promotion.
+- **Story- and sprint-level state sync** (PR #167, issue #135): `state sync --from-disk` now parses `epics.md` for stories + walks `.rihal/phases/*/sprint-*.md` for sprint entries. Status preservation verified end-to-end.
+- **`docs/verification/v2.0-gap-fixes.md`** (PR #168, issue #136): 9-row verification matrix confirming the v2.0 gap batch is intact.
+- **`docs/parking-lot-convention.md`**: 999.x numbering documentation.
+
+### Changed
+
+- **Workflow shrinkage:** `rihal/workflows/progress.md` dropped from 573 to 184 lines (68% reduction) — CLI does the thinking, workflow renders.
+- **`/rihal:status`** and **`/rihal:progress`** both call the same CLI subcommand — guaranteed consistency, closes the seam from issue #131.
+- **README** install command updated to `npx @hanzlaa/rcode install`.
+
+### Fixed
+
+- Self-drift on the rihal-code repo itself — phases 04, 05 now have proper `number` fields in `.rihal/state.json`, drift-detection reports clean.
+
+### Deferred to follow-ups (issues open in v3.0 milestone)
+
+- Full skill-folder reorganization under role directories (#179).
+- Real Rihal brain URLs (#162) — pending Rihal approval.
+- CI Actions quota fix (#165) — pending billing action.
+
+---
+
 ## v2.0.0 — Rihal Brain (unreleased)
 
 **Repositioning release.** Rihal Code is no longer a generic AI-engineering methodology that happens to be written at Rihal. It is **the installable context-brain for Rihalians** — every Rihal project can now pull PR standards, commit conventions, architecture docs, and internal guides straight from Rihal's own repos into the AI assistant's context on install.

--- a/README.md
+++ b/README.md
@@ -54,21 +54,26 @@ It's not a chatbot. It's a methodology.
 
 ## Install — one command
 
-In any project directory:
+In any project directory (existing codebase OR empty folder):
 
 ```bash
 npx @hanzlaa/rcode install
 ```
 
-That's it. One unified installer. Pure file shipping, no runtime dependencies. Installs into:
+[Live on npm](https://www.npmjs.com/package/@hanzlaa/rcode) as `@hanzlaa/rcode` · current version `v2.1.0`. See [`docs/install.md`](docs/install.md) for flavors (module subsets, IDE options, version pinning, yolo mode).
+
+One unified installer. Pure file shipping, no runtime dependencies. Installs into:
 
 - `.rihal/` — config, workflows, references, bin (Rihal infrastructure)
 - `.claude/agents/` — 44 first-class subagents
 - `.claude/commands/rihal/` — 93 slash commands
 - `.claude/skills/` — 58 phrase-activated skills (scaffold-project, create-prd, retrospective, etc.)
+- `rihal/brain/` — Rihal standards pulled from upstream (PR / commit / architecture docs)
 - `.planning/` — where your artifacts land (council sessions, plans, chains, summaries)
 
 Restart Claude Code (or your IDE), type `/`, and every `rihal:*` command appears.
+
+Update anytime with `npx @hanzlaa/rcode update` (or `/rihal:update` inside a Claude session).
 
 ### Then begin the rihla
 

--- a/docs/DAILY-USE.md
+++ b/docs/DAILY-USE.md
@@ -10,7 +10,7 @@ A practical guide to using Rihal Code on your own projects day-to-day.
 
 ```bash
 cd my-project
-npx @hanzlahabib/rihal-code install
+npx @hanzlaa/rcode install
 ```
 
 That's it. After install you'll have:
@@ -155,10 +155,10 @@ Say the phrase — Claude matches the skill automatically:
 Switch between quality/balanced/budget/inherit:
 
 ```bash
-npx rihal-code set-profile balanced  # default
-npx rihal-code set-profile quality   # opus for most agents
-npx rihal-code set-profile budget    # haiku for most agents
-npx rihal-code set-profile inherit   # follow session model
+npx @hanzlaa/rcode set-profile balanced  # default
+npx @hanzlaa/rcode set-profile quality   # opus for most agents
+npx @hanzlaa/rcode set-profile budget    # haiku for most agents
+npx @hanzlaa/rcode set-profile inherit   # follow session model
 ```
 
 ---
@@ -189,7 +189,7 @@ Workflows call these under the hood — you rarely need them directly.
 ## Dashboard (optional)
 
 ```bash
-npx rihal-code dashboard
+npx @hanzlaa/rcode dashboard
 ```
 
 Opens a view-only dashboard at `http://localhost:7717` showing phases, sprints, council sessions, and velocity charts.
@@ -199,7 +199,7 @@ Opens a view-only dashboard at `http://localhost:7717` showing phases, sprints, 
 ## Updating Rihal
 
 ```bash
-npx rihal-code update
+npx @hanzlaa/rcode update
 ```
 
 Refreshes installed agents/commands/workflows without touching your state or planning artifacts. Backs up the previous state to `.rihal/backups/update-{ts}.tgz`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,7 +71,7 @@ Binary — if either fires, we cut scope or pivot:
 ### v3.x — Internal Rihal registry
 **Goal:** Rihalians install from an internal source, not GitHub. Faster, access-controlled, audit-trailed.
 
-- Replaces `npx rihal-code@latest` as the primary install path for Rihal employees.
+- Replaces `npx @hanzlaa/rcode@latest` as the primary install path for Rihal employees.
 - GitHub release stays available for non-Rihalian contributors and for transparency.
 
 ---

--- a/docs/TIERS.md
+++ b/docs/TIERS.md
@@ -75,10 +75,10 @@ Majlis (multi-agent council) · Raees (orchestrator) · Zayd (ML) · Hanzla (eng
 
 ### Power tools
 
-- `npx rihal-code dashboard` — launches Diwan view-only dashboard on :7717
-- `npx rihal-code digest` — compact agent summaries
-- `npx rihal-code github-sync` — sync phases/epics/stories to GitHub issues
-- `npx rihal-code context --refresh` — refresh memory bank from current repo state
+- `npx @hanzlaa/rcode dashboard` — launches Diwan view-only dashboard on :7717
+- `npx @hanzlaa/rcode digest` — compact agent summaries
+- `npx @hanzlaa/rcode github-sync` — sync phases/epics/stories to GitHub issues
+- `npx @hanzlaa/rcode context --refresh` — refresh memory bank from current repo state
 
 ---
 
@@ -103,7 +103,7 @@ Covers:
 
 ## CLI Commands at a Glance
 
-Grouped by purpose (full help: `npx rihal-code help`):
+Grouped by purpose (full help: `npx @hanzlaa/rcode help`):
 
 ### Project commands
 `install` · `update` · `uninstall` · `config` · `context` · `github-sync`

--- a/docs/V2-PREVIEW.md
+++ b/docs/V2-PREVIEW.md
@@ -21,7 +21,7 @@ In v1.0-beta we unified both into a single landscape under `rihal/`:
 - `rihal/skills/` — 22 action skills + 17 agent skills (preserved from v1)
 - `rihal/references/`, `rihal/bin/`, `rihal/modules/`, `rihal/team.yaml` — v2 infrastructure
 
-One install command (`npx rihal-code install`) ships everything.
+One install command (`npx @hanzlaa/rcode install`) ships everything.
 
 ## Why keep this note?
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,184 @@
+# Installing Rihal Code
+
+Package: [`@hanzlaa/rcode`](https://www.npmjs.com/package/@hanzlaa/rcode) on npm.
+Current version: **v2.1.0** (2026-04-24).
+
+---
+
+## Quick start
+
+In any project directory (existing codebase OR empty folder):
+
+```bash
+npx @hanzlaa/rcode install
+```
+
+That's it. One command ships everything. No `npm install -g` needed — npx runs the latest published version every time.
+
+---
+
+## What gets installed
+
+After the command completes, your project has:
+
+| Path | What's inside |
+|------|---------------|
+| `.rihal/` | Config, workflows, references, binary CLI (`rihal-tools.cjs`) |
+| `.claude/agents/` | 44 first-class subagents (Sadiq, Waleed, Layla, Fatima, etc.) |
+| `.claude/commands/rihal/` | 93 slash commands (`/rihal:create-prd`, `/rihal:council`, ...) |
+| `.claude/skills/` | 58 phrase-activated skills |
+| `.planning/` | Your project's artifacts land here (councils, plans, sprints, summaries) |
+| `rihal/brain/` | Rihal standards pulled from upstream (M5 in-progress, currently scaffolds with placeholders) |
+
+Total install footprint: ~3.8 MB, 676 files.
+
+---
+
+## Pick your install flavor
+
+### Default — full install, guided mode
+```bash
+npx @hanzlaa/rcode install
+```
+
+- All 44 agents, 93 commands, 58 skills
+- Mode: `guided` (skills halt at menus for user input)
+- Language: English
+- Model profile: `balanced`
+- IDE: `claude` (Claude Code native)
+
+### Different IDE
+```bash
+npx @hanzlaa/rcode install --ide claude    # default
+npx @hanzlaa/rcode install --ide cursor
+npx @hanzlaa/rcode install --ide gemini
+```
+
+### Subset of skills — module-based install
+```bash
+npx @hanzlaa/rcode install --module core         # council + quick-sync only
+npx @hanzlaa/rcode install --module execution --force
+npx @hanzlaa/rcode install --module discovery --force
+```
+
+Use `--force` when adding a second module on top of an existing install (skips the "already installed" check).
+
+### Pin a specific version
+```bash
+npx @hanzlaa/rcode@2.1.0 install
+npx @hanzlaa/rcode@2.0.0 install
+```
+
+Version-pinned installs are reproducible — collaborators on the same repo get the same skills + agents.
+
+---
+
+## After install — first 5 minutes
+
+Start a Claude Code session in your project:
+
+```bash
+claude   # or open the project in the Cursor / Gemini variant
+```
+
+Then try any of these to kick the tires:
+
+```
+/rihal:status           — one-line dashboard
+/rihal:progress         — full progress view with Route A/B/C next-up
+/rihal:council what should we build first?
+/rihal:create-prd for a task management feature
+```
+
+If this is a new project, start with:
+
+```
+/rihal:scaffold-project      — guided project init
+/rihal:create-prd            — PRD through structured facilitation
+/rihal:create-milestone      — design the M1..Mn roadmap from the PRD
+/rihal:create-epics-and-stories   — break M1 into sprint-ready stories
+/rihal:sprint-planning       — capacity-gated sprint plan
+/rihal:dev-story             — implement one story end-to-end
+/rihal:progress              — see where you are, what's next
+```
+
+---
+
+## Updating
+
+```bash
+npx @hanzlaa/rcode update
+```
+
+That pulls the latest methodology + refreshes the brain content (see `rihal/brain/`). Your project's `.rihal/config.yaml` and `.rihal/state.json` are preserved — only the methodology files get refreshed.
+
+To pin to a specific version on update:
+
+```bash
+/rihal:update v2.0.0   # inside a Claude session
+```
+
+---
+
+## Yolo mode (autonomous, less halt-at-menu)
+
+Default mode is `guided` — skills stop at decision menus and wait for you. If you want skills to auto-advance using the best inference from context:
+
+Edit `.rihal/config.yaml`:
+```yaml
+mode: yolo
+```
+
+Yolo still respects the research citation rule, state sync rule, and capacity gate. It only bypasses confirmation menus. See [`docs/running-autonomously.md`](running-autonomously.md).
+
+---
+
+## Uninstalling
+
+Rihal Code is pure file-shipping with no persistent runtime. To remove:
+
+```bash
+rm -rf .rihal/ .claude/ .planning/ rihal/brain/
+```
+
+Your git history of your own project's artifacts in `.planning/` is yours — back up before `rm -rf` if you want to keep them.
+
+---
+
+## Troubleshooting
+
+### `command not found: claude`
+Install Claude Code first: see https://claude.ai/code. Rihal Code is a package you install *into* Claude Code / Cursor / Gemini — it doesn't ship the IDE itself.
+
+### Install succeeds but skills don't activate
+Make sure you're running in the directory that has `.claude/skills/`. Some IDEs require a restart after a new skill folder appears. Claude Code: `Cmd+Shift+P → Reload Window`.
+
+### `npx @hanzlaa/rcode` hangs at "resolving packages"
+npm registry mirror issue. Try `npm config set registry https://registry.npmjs.org/` then re-run.
+
+### Collaborator on the same repo sees different skills
+Someone ran `rihal-code update` and the other hasn't. Either commit the `.rihal/` changes (they're git-friendly) or standardize on a pinned version.
+
+### Want to uninstall one module but keep others
+Not yet supported. Re-install with only the modules you want via `--module` flags + `--force`.
+
+---
+
+## Legacy install command (still works)
+
+The legacy binary name `rihal-code` is kept as an alias for backward compatibility with older docs:
+
+```bash
+npx rihal-code install     # works, same as @hanzlaa/rcode install
+```
+
+New docs and CI should prefer `npx @hanzlaa/rcode install`.
+
+---
+
+## Next
+
+- Read [`docs/what-is-rihal-code.md`](what-is-rihal-code.md) for the product story.
+- Read [`docs/TIERS.md`](TIERS.md) to pick what to try first.
+- Read [`docs/ROADMAP.md`](ROADMAP.md) to see where this is going (v3 MCP server on the horizon).
+- If you want to contribute, read [`CONTRIBUTING.md`](../CONTRIBUTING.md) — per-role guide.

--- a/docs/verification/v2.0-gap-fixes.md
+++ b/docs/verification/v2.0-gap-fixes.md
@@ -32,7 +32,7 @@ In a fresh scratch directory:
 
 ```bash
 mkdir /tmp/rihal-verify && cd /tmp/rihal-verify
-npx @hanzlahabib/rihal-code@v2.0.0 install
+npx @hanzlaa/rcode@v2.0.0 install
 claude  # open Claude Code
 ```
 

--- a/examples/starter-walkthrough.md
+++ b/examples/starter-walkthrough.md
@@ -11,7 +11,7 @@ This walkthrough takes you from an empty directory to a planned sprint in ~10 mi
 ## 1. Install Rihal Code
 
 ```bash
-npx @hanzlahabib/rihal-code install
+npx @hanzlaa/rcode install
 ```
 
 ## 2. Initialize a new project

--- a/rihal/workflows/dashboard.md
+++ b/rihal/workflows/dashboard.md
@@ -27,14 +27,14 @@ Check for the dashboard server in priority order:
 
 1. `./server/dashboard.js` (when inside the rihal-code source repo)
 2. `./.rihal/lib/server/dashboard.js` (installed package copy)
-3. `$(npm root -g)/@hanzlahabib/rihal-code/server/dashboard.js` (global install)
+3. `$(npm root -g)/@hanzlaa/rcode/server/dashboard.js` (global install)
 
 Store the resolved path as `$DASHBOARD`.
 
 If none found, print:
 ```
 ❌ Dashboard script not found.
-Run `npx rihal-code install` to install the package, or check you're inside a project with .rihal/.
+Run `npx @hanzlaa/rcode install` to install the package, or check you're inside a project with .rihal/.
 ```
 Exit.
 

--- a/rihal/workflows/install.md
+++ b/rihal/workflows/install.md
@@ -50,8 +50,8 @@ The installer needs to be called with the `--module` flag. Detect the rihal-code
 # Try local dev first, then global
 if [ -f ./cli/install-v2.js ]; then
   node ./cli/install-v2.js . --module {name} --force --yes
-elif [ -f "$(npm root -g)/@hanzlahabib/rihal-code/cli/install-v2.js" ]; then
-  node "$(npm root -g)/@hanzlahabib/rihal-code/cli/install-v2.js" . --module {name} --force --yes
+elif [ -f "$(npm root -g)/@hanzlaa/rcode/cli/install-v2.js" ]; then
+  node "$(npm root -g)/@hanzlaa/rcode/cli/install-v2.js" . --module {name} --force --yes
 else
   echo "Cannot find rihal-code package. Install it globally or run from the repo."
   exit 1

--- a/rihal/workflows/progress.md
+++ b/rihal/workflows/progress.md
@@ -179,6 +179,6 @@ If `SNAPSHOT.routes[]` is empty or only has fallback entries, print:
 
 ## On Error
 
-- **CLI missing:** "Rihal Code install missing or stale. Run: npx @hanzlahabib/rihal-code install"
+- **CLI missing:** "Rihal Code install missing or stale. Run: npx @hanzlaa/rcode install"
 - **CLI returns `ok: false`:** surface the CLI's error verbatim. Do not attempt to compensate — the CLI's failures are the source of truth on what's wrong.
 - **Network-dependent insights:** there should be none. Insights are computed from local state + disk only.

--- a/rihal/workflows/status.md
+++ b/rihal/workflows/status.md
@@ -111,6 +111,6 @@ Group routes by letter. If multiple routes share a letter, list them indented. I
 
 ## On Error
 
-- **CLI not found:** "Rihal Code install missing. Run: npx @hanzlahabib/rihal-code install"
+- **CLI not found:** "Rihal Code install missing. Run: npx @hanzlaa/rcode install"
 - **state.json invalid JSON:** report the CLI's exact error string — the CLI already has a clean error shape.
 - **Unexpected shape:** fall back to the banner + "State present but unreadable. Try: node .rihal/bin/rihal-tools.cjs state read"


### PR DESCRIPTION
Follows release of \`@hanzlaa/rcode@2.1.0\` to npm.

## What's new

- **\`docs/install.md\`** — single dedicated install guide. Covers:
  - Quick start: \`npx @hanzlaa/rcode install\`
  - Flavors (module subsets, IDE options, version pinning)
  - First 5 minutes (what to try after install)
  - Update flow
  - Yolo mode opt-in
  - Uninstall
  - 5 troubleshooting scenarios
  - Legacy alias note (\`rihal-code\` still works)

- **README install section** — points at docs/install.md, links the npm page, mentions the update command + brain content.

- **CHANGELOG v2.1.0 entry** — documents the npm publish, M2.5 bundle, story-level state sync, verification matrix, and deferrals.

## Bulk rename

Across user-facing docs only (tier docs, workflows, examples, verification):
- \`npx rihal-code ...\` → \`npx @hanzlaa/rcode ...\`
- \`@hanzlahabib/rihal-code\` → \`@hanzlaa/rcode\`

13 files touched. Historical docs untouched:
- \`docs/adr/*\` — ADRs record history, shouldn't be rewritten.
- \`.planning/*\` — project's own state, gitignored subset.

## Safety

- \`rihal-code\` bin alias remains in package.json — any legacy \`rihal-code foo\` invocation in older copied docs or collaborator scripts still works.
- GitHub URLs (\`github.com/hanzlahabib/rihal-code\`) untouched — repo owner unchanged, only npm package name moved.