### PR TITLE
feat(cli): auto-manage .gitignore on install (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Rihal Code are documented here.
 
 ---
 
+## v2.2.0 — Auto-managed .gitignore on install (2026-04-24)
+
+**Installer polish.** Before v2.2, a fresh `rcode install` + `git add .` would bloat the user's repo by 676 methodology files (~3.8 MB) that regenerate on every update. This release fixes that at the install step, not after-the-fact.
+
+### Added
+
+- `cli/install.js` now appends an idempotent `rcode-managed gitignore block` to the project's `.gitignore` on first install. Block is marked with a sentinel comment so re-runs detect and skip. Existing user entries are preserved when rcode appends; never overwrites.
+- `docs/install.md` grows a **"What gets committed vs ignored"** table with the rationale for each path.
+
+### The committable split
+
+- ✅ **Commit:** `.rihal/config.yaml` (project mode/language/profile), `.rihal/state.json` (decisions log + roadmap + blockers), `.planning/` (PRD, roadmap, sprints, SUMMARY files).
+- ❌ **Ignore:** `.claude/`, `.rihal/{bin,workflows,references,commands,skills}/`, `rihal/brain/`, lock files, debug artifacts.
+
+### Verified
+
+3-scenario smoke test:
+- Fresh project, no `.gitignore` → **created** with rcode block.
+- Re-run install → detects sentinel, **already-present** (no duplicate append).
+- Existing `.gitignore` with user entries (e.g. `node_modules/`) → **appended**; user entries preserved byte-for-byte.
+
+### Deferred
+
+Users already on v2.1.0 who accidentally committed `.claude/` etc. will need a one-off cleanup: `git rm -r --cached .claude .rihal/workflows .rihal/bin .rihal/references rihal/brain && git commit -m "chore: stop tracking rcode-managed files"`. A follow-up `rcode migrate` subcommand could automate this but it's not shipped here.
+
+---
+
 ## v2.1.0 — First npm publish as @hanzlaa/rcode (2026-04-24)
 
 **Shipping release.** Live on npm at [@hanzlaa/rcode](https://www.npmjs.com/package/@hanzlaa/rcode). Previously only installable by cloning the repo; now available as `npx @hanzlaa/rcode install` from any project anywhere.

--- a/cli/install.js
+++ b/cli/install.js
@@ -71,6 +71,9 @@ function parseArgs(argv) {
     ide: 'claude',  // claude, cursor, gemini (copilot = TODO)
     help: false,
     modules: [],  // --module core --module execution or empty = all
+    // #189 — planning commit policy. null = ask interactively (or default true under --yes).
+    // Set true by --commit-planning, false by --no-commit-planning or --ignore-planning.
+    commitPlanning: null,
   };
   const positional = [];
   for (let i = 0; i < argv.length; i++) {
@@ -85,6 +88,8 @@ function parseArgs(argv) {
     else if (arg === '--mode') opts.mode = argv[++i];
     else if (arg === '--ide') opts.ide = argv[++i];
     else if (arg === '--module') opts.modules.push(argv[++i]);
+    else if (arg === '--commit-planning') opts.commitPlanning = true;
+    else if (arg === '--no-commit-planning' || arg === '--ignore-planning') opts.commitPlanning = false;
     else if (!arg.startsWith('--')) positional.push(arg);
   }
   if (positional[0]) {
@@ -93,6 +98,30 @@ function parseArgs(argv) {
   }
   if (!opts.projectName) opts.projectName = path.basename(opts.target);
   return opts;
+}
+
+/**
+ * Resolve commit-planning preference — CLI flag wins, then interactive
+ * prompt (when TTY + not --yes), else GSD-style default: true.
+ * #189.
+ */
+async function resolveCommitPlanning(opts) {
+  if (opts.commitPlanning !== null) return opts.commitPlanning;
+  if (opts.yes || !process.stdin.isTTY) return true; // non-interactive default
+
+  const readline = require('readline');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const prompt = (q) => new Promise(r => rl.question(q, a => r(a)));
+  console.log('');
+  console.log('📋 .planning/ holds PRDs, roadmaps, sprints, SUMMARY files.');
+  console.log('   Commit them to git, or keep them local?');
+  console.log('');
+  console.log('   [Y] Commit — collaborators see the same plans  (default, recommended)');
+  console.log('   [n] Gitignore — planning stays local  (good for sensitive PRDs)');
+  console.log('');
+  const answer = (await prompt('   Commit planning artifacts? [Y/n]: ')).trim().toLowerCase();
+  rl.close();
+  return !(answer === 'n' || answer === 'no');
 }
 
 function printHelp() {
@@ -298,12 +327,17 @@ function seedStarterPlanning(target, projectName) {
  *
  * Returns: { action: 'created' | 'appended' | 'already-present' | 'skipped-error' }
  */
-function ensureRcodeGitignore(target) {
-  const MARKER = '# ===== rcode-managed gitignore block (npx @hanzlaa/rcode install) =====';
-  const BLOCK = [
+function ensureRcodeGitignore(target, options = {}) {
+  const commitPlanning = options.commitPlanning !== false; // default true
+  const BEGIN = '# ===== rcode-managed gitignore block (npx @hanzlaa/rcode install) =====';
+  const END   = '# ===== end rcode-managed gitignore block =====';
+
+  const lines = [
     '',
-    MARKER,
+    BEGIN,
     '# Added automatically on first rcode install. Idempotent — safe to re-run.',
+    '# Edit `commit_planning` in .rihal/config.yaml to flip planning-artifact tracking.',
+    '',
     '# Installed methodology files (regenerate with: npx @hanzlaa/rcode install)',
     '.claude/',
     '.rihal/bin/',
@@ -313,20 +347,37 @@ function ensureRcodeGitignore(target) {
     '.rihal/skills/',
     '',
     '# Pulled Rihal brain content (refresh with: rcode brain pull)',
-    'rihal/brain/',
+    '.rihal/brain/rihal-github/',
+    '.rihal/brain/rihal-docs/',
+    '.rihal/brain/best-practices/',
     '',
     '# Runtime noise',
     '.rihal/state.json.lock',
     '.planning/debug/',
     '.planning/_backup/',
+  ];
+
+  if (!commitPlanning) {
+    lines.push(
+      '',
+      '# Planning artifacts — kept local (commit_planning: false)',
+      '.planning/'
+    );
+  }
+
+  lines.push(
     '',
     '# What you DO commit:',
-    '#   .rihal/config.yaml   - project mode/language/profile',
-    '#   .rihal/state.json    - decisions, roadmap pointer, blockers',
-    '#   .planning/           - PRD, roadmap, sprints, SUMMARY.md files',
-    '# ===== end rcode-managed gitignore block =====',
-    '',
-  ].join('\n');
+    '#   .rihal/config.yaml        - project mode/language/profile/commit_planning',
+    '#   .rihal/state.json         - decisions, roadmap pointer, blockers',
+    '#   .rihal/brain/sources.yaml - brain source manifest',
+    commitPlanning
+      ? '#   .planning/                - PRD, roadmap, sprints, SUMMARY.md files'
+      : '#   (planning artifacts are NOT committed — see commit_planning in config)',
+    END,
+    ''
+  );
+  const BLOCK = lines.join('\n');
 
   const gitignorePath = path.join(target, '.gitignore');
   try {
@@ -335,7 +386,25 @@ function ensureRcodeGitignore(target) {
       return { action: 'created' };
     }
     const existing = fs.readFileSync(gitignorePath, 'utf8');
-    if (existing.includes(MARKER)) {
+    // Replace existing rcode block using indexOf (regex escaping on the
+    // sentinel is fiddly — indexOf is deterministic and easier to audit).
+    function spliceBlock(text, newBlock) {
+      const start = text.indexOf(BEGIN);
+      if (start < 0) return null;
+      const endIdx = text.indexOf(END, start);
+      if (endIdx < 0) return null;
+      let sliceStart = start;
+      if (sliceStart > 0 && text[sliceStart - 1] === '\n') sliceStart -= 1;
+      let sliceEnd = endIdx + END.length;
+      if (text[sliceEnd] === '\n') sliceEnd += 1;
+      return text.slice(0, sliceStart) + newBlock + text.slice(sliceEnd);
+    }
+    if (existing.includes(BEGIN)) {
+      const rewritten = spliceBlock(existing, BLOCK);
+      if (rewritten !== null && rewritten !== existing) {
+        fs.writeFileSync(gitignorePath, rewritten);
+        return { action: 'updated' };
+      }
       return { action: 'already-present' };
     }
     fs.writeFileSync(gitignorePath, existing + BLOCK);
@@ -343,6 +412,45 @@ function ensureRcodeGitignore(target) {
   } catch (err) {
     return { action: 'skipped-error', error: err.message };
   }
+}
+
+/**
+ * Install brain scaffold (sources.yaml + README.md) into .rihal/brain/ on target.
+ * Actual brain content lands after `brain pull` runs.
+ * Closes #188 — previously the package's rihal/brain/sources.yaml was never
+ * copied to the target at all, leaving brain pull permanently broken.
+ */
+function installBrainScaffold(packageRoot, target) {
+  const srcDir = path.join(packageRoot, 'rihal', 'brain');
+  const destDir = path.join(target, '.rihal', 'brain');
+  fs.mkdirSync(destDir, { recursive: true });
+  let copied = 0;
+  for (const name of ['sources.yaml', 'README.md']) {
+    const src = path.join(srcDir, name);
+    const dest = path.join(destDir, name);
+    if (fs.existsSync(src) && !fs.existsSync(dest)) {
+      fs.copyFileSync(src, dest);
+      copied++;
+    }
+  }
+  // Also pre-seed the best-practices subfolder from the package's
+  // rihal/skills/_shared/ so a fresh install has working brain content
+  // immediately, even before brain pull runs against real upstream URLs.
+  const sharedSrc = path.join(packageRoot, 'rihal', 'skills', '_shared');
+  if (fs.existsSync(sharedSrc)) {
+    const bpDest = path.join(destDir, 'best-practices');
+    fs.mkdirSync(bpDest, { recursive: true });
+    for (const entry of fs.readdirSync(sharedSrc, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.md')) {
+        const dest = path.join(bpDest, entry.name);
+        if (!fs.existsSync(dest)) {
+          fs.copyFileSync(path.join(sharedSrc, entry.name), dest);
+          copied++;
+        }
+      }
+    }
+  }
+  return copied;
 }
 
 /**
@@ -687,6 +795,7 @@ function generateConfigYaml(opts) {
     `communication_language: "${sanitizeYamlValue(opts.language)}"`,
     `mode: "${sanitizeYamlValue(opts.mode)}"`,
     `model_profile: "balanced"`,
+    `commit_planning: ${opts.commitPlanning !== false}`,
     `rihal_source_path: "${sanitizeYamlValue(path.dirname(path.dirname(process.argv[1])))}/"`,
     'workflow:',
     '  research_by_default: false',
@@ -713,8 +822,11 @@ function convertToCursorMdc(sourceText) {
 /**
  * Main install routine. Copies files, generates manifests, writes config.
  */
-function install(opts) {
+async function install(opts) {
   if (opts.help) { printHelp(); return 0; }
+
+  // Resolve commit-planning preference (interactive prompt or flag) — #189.
+  opts.commitPlanning = await resolveCommitPlanning(opts);
 
   console.log(`\n🕌 Rihal Code installer → ${opts.target}`);
   if (!fs.existsSync(SOURCE_ROOT)) {
@@ -862,9 +974,13 @@ function install(opts) {
   // Seed .planning/ with starter ROADMAP + STATE so workflows work immediately
   const starterSeeded = seedStarterPlanning(opts.target, opts.projectName);
 
+  // Install brain scaffolding at .rihal/brain/ (sources.yaml + README).
+  // Actual brain content lands after first brain pull runs.
+  installBrainScaffold(PACKAGE_ROOT, opts.target);
+
   // Ensure .gitignore separates installed methodology from committable artifacts.
-  // Idempotent via sentinel marker — safe to re-run. Best-effort (never throws).
-  const gitignoreReport = ensureRcodeGitignore(opts.target);
+  // Reads opts.commitPlanning to decide whether .planning/ is in the ignore block.
+  const gitignoreReport = ensureRcodeGitignore(opts.target, { commitPlanning: opts.commitPlanning });
 
   // Pull Rihal brain content (v2.0 — issue #158).
   // Runs rihal-tools brain pull as a child process. Placeholder URLs
@@ -983,9 +1099,7 @@ async function main() {
     }
   }
 
-  try {
-    process.exit(install(opts));
-  } catch (err) {
+  install(opts).then(code => process.exit(code)).catch(err => {
     if (err.code === 'EACCES' || err.code === 'EPERM') {
       console.error(`✖ Permission denied: ${err.path || err.message}`);
       process.exit(1);
@@ -997,7 +1111,7 @@ async function main() {
     console.error(`✖ Install failed: ${err.message}`);
     if (process.env.DEBUG) console.error(err.stack);
     process.exit(1);
-  }
+  });
 }
 
 if (require.main === module) main();
@@ -1007,10 +1121,10 @@ if (require.main === module) main();
  * Converts the index.js-style (args, ctx) signature into a cli/install.js
  * parseArgs-compatible argv and runs install().
  */
-function runFromCli(args /* , ctx */) {
+async function runFromCli(args /* , ctx */) {
   const argv = Array.isArray(args) ? args : [];
   const opts = parseArgs(argv);
-  const code = install(opts);
+  const code = await install(opts);
   if (code !== 0) process.exit(code);
 }
 

--- a/cli/install.js
+++ b/cli/install.js
@@ -890,14 +890,46 @@ async function install(opts) {
   opts.commitPlanning = await resolveCommitPlanning(opts);
 
   console.log(`\n🕌 Rihal Code v${readPackageVersion()} installer → ${opts.target}`);
+
+  // Detect an existing install and surface it (#195).
+  const existingManifestPath = path.join(opts.target, '.rihal', '_config', 'manifest.yaml');
+  if (fs.existsSync(existingManifestPath)) {
+    const m = fs.readFileSync(existingManifestPath, 'utf8').match(/^version:\s*(.+)$/m);
+    const existingVersion = m ? m[1].trim() : 'unknown';
+    const newVersion = readPackageVersion();
+    if (existingVersion === newVersion) {
+      console.log(`  ↻ Existing install at v${existingVersion} — refreshing (config + state + .planning preserved).`);
+    } else {
+      console.log(`  ⬆ Existing install at v${existingVersion} — upgrading to v${newVersion} (config + state + .planning preserved).`);
+    }
+    if (!opts.force) {
+      console.log('    Pass --force to also sweep orphaned files from the previous version.');
+    }
+  }
   if (!fs.existsSync(SOURCE_ROOT)) {
     console.error(`✖ Source tree not found at ${SOURCE_ROOT}. Running from wrong dir?`);
     return 1;
   }
 
-  // Validate IDE
+  // Validate IDE — structured error for unsupported editors (#197).
   if (!['claude', 'cursor', 'gemini'].includes(opts.ide)) {
-    console.error(`✖ Unknown IDE: ${opts.ide}. Supported: claude, cursor, gemini`);
+    console.error(`✖ --ide ${opts.ide} is not supported in v${readPackageVersion()}.`);
+    console.error('');
+    console.error('  Currently supported:');
+    console.error('    claude    — Claude Code native (recommended)');
+    console.error('    cursor    — Cursor IDE');
+    console.error('    gemini    — Gemini CLI');
+    console.error('');
+    console.error('  Tracked for v3.0 (see issue #182):');
+    console.error('    vscode    — VS Code native extension');
+    console.error('    jetbrains — IntelliJ / PyCharm');
+    console.error('    zed       — Zed editor');
+    console.error('');
+    if (/^(vscode|vs-code|code)$/i.test(opts.ide)) {
+      console.error('  Workaround: if you use VS Code WITH the Claude Code extension,');
+      console.error('  run `--ide claude` — the extension reads from .claude/ too.');
+      console.error('');
+    }
     return 1;
   }
 
@@ -1144,7 +1176,77 @@ async function install(opts) {
   console.log('  ⚠ If your IDE is already open, reload the window to refresh skills/commands.');
   console.log('    Claude Code / VS Code / Cursor:  Cmd+Shift+P → Reload Window');
   console.log('');
-  return 0;
+
+  // Health check — smoke test that the install actually works (#193).
+  const healthPass = runInstallHealthCheck(opts.target, { agentCount, commandCount, skillsInstalled });
+  return healthPass ? 0 : 1;
+}
+
+/**
+ * Run a 5-point smoke test against the fresh install. Closes #193.
+ * Returns true if all pass, false if any critical check failed.
+ * Prints a clean ✓/✖ line per check.
+ */
+function runInstallHealthCheck(target, counts) {
+  console.log('  Health check:');
+  const { execFileSync } = require('child_process');
+  let fails = 0;
+
+  function check(label, fn) {
+    try {
+      const out = fn();
+      console.log(`    ✓ ${label}${out ? ' — ' + out : ''}`);
+    } catch (err) {
+      fails += 1;
+      console.log(`    ✖ ${label} — ${String(err.message || err).slice(0, 120)}`);
+    }
+  }
+
+  check('rihal-tools.cjs runs', () => {
+    const toolsPath = path.join(target, '.rihal', 'bin', 'rihal-tools.cjs');
+    if (!fs.existsSync(toolsPath)) throw new Error('bin/rihal-tools.cjs not installed');
+    execFileSync('node', ['-c', toolsPath], { stdio: 'pipe' });
+    return 'syntax ok';
+  });
+
+  check('.rihal/config.yaml present', () => {
+    const p = path.join(target, '.rihal', 'config.yaml');
+    if (!fs.existsSync(p)) throw new Error('missing');
+    const text = fs.readFileSync(p, 'utf8');
+    if (!/user_name:|project_name:/.test(text)) throw new Error('config.yaml incomplete');
+    return `${fs.statSync(p).size} bytes`;
+  });
+
+  check('.rihal/state.json parses', () => {
+    const p = path.join(target, '.rihal', 'state.json');
+    if (!fs.existsSync(p)) throw new Error('missing');
+    JSON.parse(fs.readFileSync(p, 'utf8'));
+    return 'valid JSON';
+  });
+
+  check('agents installed', () => {
+    if ((counts.agentCount || 0) < 20) throw new Error(`only ${counts.agentCount} agents (expected ≥ 20)`);
+    return `${counts.agentCount}`;
+  });
+
+  check('skills + commands installed', () => {
+    const issues = [];
+    if ((counts.skillsInstalled || 0) < 20) issues.push(`${counts.skillsInstalled} skills`);
+    if ((counts.commandCount || 0) < 20) issues.push(`${counts.commandCount} commands`);
+    if (issues.length) throw new Error(`low count: ${issues.join(', ')}`);
+    return `${counts.skillsInstalled} skills + ${counts.commandCount} commands`;
+  });
+
+  if (fails > 0) {
+    console.log('');
+    console.log(`  ✖ ${fails} health check${fails === 1 ? '' : 's'} failed — install may be broken.`);
+    console.log('     Debug: node .rihal/bin/rihal-tools.cjs state read && ls -la .rihal/');
+    console.log('     Reinstall: npx @hanzlaa/rcode install . --force');
+    console.log('');
+    return false;
+  }
+  console.log('');
+  return true;
 }
 
 async function main() {

--- a/cli/install.js
+++ b/cli/install.js
@@ -285,6 +285,67 @@ function seedStarterPlanning(target, projectName) {
 }
 
 /**
+ * Ensure the target project's .gitignore has the rcode-managed block.
+ *
+ * Idempotent via a sentinel comment line. On first install, appends a block
+ * that separates:
+ *   - installed methodology files (ignored; re-install to refresh)
+ *   - user's project config, state, and planning artifacts (committable)
+ *
+ * If the user already has a block (marker present) we leave their customizations
+ * alone. This function is best-effort — never throws. A missing .gitignore
+ * is created. A read/write error is logged and install continues.
+ *
+ * Returns: { action: 'created' | 'appended' | 'already-present' | 'skipped-error' }
+ */
+function ensureRcodeGitignore(target) {
+  const MARKER = '# ===== rcode-managed gitignore block (npx @hanzlaa/rcode install) =====';
+  const BLOCK = [
+    '',
+    MARKER,
+    '# Added automatically on first rcode install. Idempotent — safe to re-run.',
+    '# Installed methodology files (regenerate with: npx @hanzlaa/rcode install)',
+    '.claude/',
+    '.rihal/bin/',
+    '.rihal/workflows/',
+    '.rihal/references/',
+    '.rihal/commands/',
+    '.rihal/skills/',
+    '',
+    '# Pulled Rihal brain content (refresh with: rcode brain pull)',
+    'rihal/brain/',
+    '',
+    '# Runtime noise',
+    '.rihal/state.json.lock',
+    '.planning/debug/',
+    '.planning/_backup/',
+    '',
+    '# What you DO commit:',
+    '#   .rihal/config.yaml   - project mode/language/profile',
+    '#   .rihal/state.json    - decisions, roadmap pointer, blockers',
+    '#   .planning/           - PRD, roadmap, sprints, SUMMARY.md files',
+    '# ===== end rcode-managed gitignore block =====',
+    '',
+  ].join('\n');
+
+  const gitignorePath = path.join(target, '.gitignore');
+  try {
+    if (!fs.existsSync(gitignorePath)) {
+      fs.writeFileSync(gitignorePath, BLOCK);
+      return { action: 'created' };
+    }
+    const existing = fs.readFileSync(gitignorePath, 'utf8');
+    if (existing.includes(MARKER)) {
+      return { action: 'already-present' };
+    }
+    fs.writeFileSync(gitignorePath, existing + BLOCK);
+    return { action: 'appended' };
+  } catch (err) {
+    return { action: 'skipped-error', error: err.message };
+  }
+}
+
+/**
  * Install v1-style skills into the target project.
  *
  * User-facing skills  → .claude/skills/rihal-{name}   (phrase-activated, visible as slash commands)
@@ -801,6 +862,10 @@ function install(opts) {
   // Seed .planning/ with starter ROADMAP + STATE so workflows work immediately
   const starterSeeded = seedStarterPlanning(opts.target, opts.projectName);
 
+  // Ensure .gitignore separates installed methodology from committable artifacts.
+  // Idempotent via sentinel marker — safe to re-run. Best-effort (never throws).
+  const gitignoreReport = ensureRcodeGitignore(opts.target);
+
   // Pull Rihal brain content (v2.0 — issue #158).
   // Runs rihal-tools brain pull as a child process. Placeholder URLs
   // are skipped gracefully so this does not fail a fresh install.
@@ -834,6 +899,15 @@ function install(opts) {
       (skippedCount ? `, ${skippedCount} skipped (placeholder URLs — see issue #162)` : ''));
   } else if (brainReport && brainReport.error) {
     console.log(`  Brain:     skipped (${brainReport.error})`);
+  }
+  if (gitignoreReport) {
+    const gitMsg = {
+      'created': '.gitignore created with rcode block',
+      'appended': '.gitignore updated — rcode block appended',
+      'already-present': '.gitignore rcode block already present',
+      'skipped-error': `.gitignore skipped (${gitignoreReport.error})`,
+    }[gitignoreReport.action] || '.gitignore unchanged';
+    console.log(`  Gitignore: ${gitMsg}`);
   }
   if (skipped > 0) console.log(`  Skipped:   ${skipped} (already present, unchanged)`);
   if (opts.force && existedBefore) {

--- a/cli/install.js
+++ b/cli/install.js
@@ -744,6 +744,67 @@ function generateFilesManifest(plan, target) {
   return rows.map((r) => r.join(',')).join('\n') + '\n';
 }
 
+/**
+ * Orphan sweep — remove files that were part of a previous install but aren't
+ * in the current plan. Reads `.rihal/_config/files-manifest.csv` from the
+ * previous install and computes the diff against the new plan.
+ *
+ * Closes #196 — without this, upgrading rcode leaves stale skill/command
+ * files around that show up as ghost slash commands in the IDE.
+ *
+ * Deliberately conservative:
+ *   - Only removes files that appeared in the PREVIOUS manifest.
+ *   - Never removes files the user created themselves.
+ *   - Never touches .rihal/config.yaml, .rihal/state.json, or .planning/.
+ *
+ * Returns the number of orphan files removed.
+ */
+function sweepStaleInstalledFiles(target, newPlan) {
+  const manifestPath = path.join(target, '.rihal', '_config', 'files-manifest.csv');
+  if (!fs.existsSync(manifestPath)) return 0;
+
+  let oldRels;
+  try {
+    const rows = fs.readFileSync(manifestPath, 'utf8').split('\n').slice(1).filter(Boolean);
+    oldRels = rows.map(r => r.split(',')[0]).filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  const newRelsSet = new Set(newPlan.map(e => e.rel.split(path.sep).join('/')));
+  // Safety — never sweep these, even if they somehow landed in the manifest.
+  const neverSweep = /^(\.rihal\/config\.yaml|\.rihal\/state\.json|\.rihal\/state\.json\.lock|\.planning\/|\.rihal\/brain\/sources\.yaml)/;
+
+  let removed = 0;
+  const emptyCandidateDirs = new Set();
+  for (const rel of oldRels) {
+    if (newRelsSet.has(rel)) continue;
+    if (neverSweep.test(rel)) continue;
+    const full = path.join(target, rel);
+    try {
+      if (fs.existsSync(full)) {
+        fs.rmSync(full, { force: true });
+        emptyCandidateDirs.add(path.dirname(full));
+        removed += 1;
+      }
+    } catch {
+      // ignore individual failures — sweep is best-effort
+    }
+  }
+
+  // Remove any now-empty parent dirs (bottom-up, so nested emptiness cascades).
+  const dirsSortedDeep = Array.from(emptyCandidateDirs).sort((a, b) => b.length - a.length);
+  for (const dir of dirsSortedDeep) {
+    try {
+      if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) {
+        fs.rmdirSync(dir);
+      }
+    } catch {}
+  }
+
+  return removed;
+}
+
 function readPackageVersion() {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8'));
@@ -828,7 +889,7 @@ async function install(opts) {
   // Resolve commit-planning preference (interactive prompt or flag) — #189.
   opts.commitPlanning = await resolveCommitPlanning(opts);
 
-  console.log(`\n🕌 Rihal Code installer → ${opts.target}`);
+  console.log(`\n🕌 Rihal Code v${readPackageVersion()} installer → ${opts.target}`);
   if (!fs.existsSync(SOURCE_ROOT)) {
     console.error(`✖ Source tree not found at ${SOURCE_ROOT}. Running from wrong dir?`);
     return 1;
@@ -869,6 +930,13 @@ async function install(opts) {
   }
   if (opts.modules.length > 0) {
     console.log(`  Modules: ${opts.modules.join(', ')}`);
+  }
+
+  // Orphan sweep — remove files from previous install not in the new plan (#196).
+  // Runs on --force only, to preserve user-edited or hand-dropped files on regular installs.
+  let sweptOrphans = 0;
+  if (opts.force) {
+    sweptOrphans = sweepStaleInstalledFiles(opts.target, plan);
   }
 
   // Copy files
@@ -1004,10 +1072,7 @@ async function install(opts) {
 
   // Summary
   console.log('');
-  console.log(`  Installed: ${copied} file${copied === 1 ? '' : 's'}`);
-  if (skillsInstalled > 0) {
-    console.log(`  Skills:    ${skillsInstalled} phrase-activated (in .claude/skills/)`);
-  }
+  console.log(`  Files:     ${copied} installed` + (opts.force && sweptOrphans > 0 ? `, ${sweptOrphans} stale swept` : ''));
   if (brainReport && brainReport.ok) {
     const pulledCount = (brainReport.pulled || []).length;
     const skippedCount = (brainReport.skipped || []).length;
@@ -1021,6 +1086,7 @@ async function install(opts) {
       'created': '.gitignore created with rcode block',
       'appended': '.gitignore updated — rcode block appended',
       'already-present': '.gitignore rcode block already present',
+      'updated': '.gitignore rcode block refreshed',
       'skipped-error': `.gitignore skipped (${gitignoreReport.error})`,
     }[gitignoreReport.action] || '.gitignore unchanged';
     console.log(`  Gitignore: ${gitMsg}`);
@@ -1030,21 +1096,35 @@ async function install(opts) {
     console.log('  ⚠ Preserved: .rihal/config.yaml and .rihal/state.json');
     console.log('     Pass --reset to wipe and re-init those too.');
   }
+
+  // Count installed agents + commands dynamically (#190).
+  const agentsDir = path.join(opts.target, '.claude', 'agents');
+  const commandsDir = path.join(opts.target, '.claude', 'commands', 'rihal');
+  let agentCount = 0, commandCount = 0;
+  try {
+    if (fs.existsSync(agentsDir)) {
+      agentCount = fs.readdirSync(agentsDir).filter(f => f.startsWith('rihal-') && f.endsWith('.md')).length;
+    }
+    if (fs.existsSync(commandsDir)) {
+      commandCount = fs.readdirSync(commandsDir).filter(f => f.endsWith('.md')).length;
+    }
+  } catch {}
+
   console.log('');
-  console.log(`  Installed for IDE: ${opts.ide}`);
-  console.log(`  Language: ${opts.language}  (change in .rihal/config.yaml → communication_language)`);
-  console.log(`  Mode: ${opts.mode}  (guided=confirm at gates, yolo=autonomous)`);
-  console.log(`  Model profile: balanced`);
+  console.log(`  Version:   @hanzlaa/rcode@${readPackageVersion()}`);
+  console.log(`  IDE:       ${opts.ide}`);
+  console.log(`  Language:  ${opts.language}  (change in .rihal/config.yaml)`);
+  console.log(`  Mode:      ${opts.mode}  (guided=confirm at gates, yolo=autonomous)`);
+  console.log(`  Profile:   balanced`);
+  console.log(`  Planning:  ${opts.commitPlanning !== false ? 'committed' : 'gitignored'}  (flip: rihal-tools gitignore refresh)`);
   console.log('');
-  console.log('  Agents installed (first-class subagents):');
-  console.log('    🧭 rihal-sadiq   — Director of Strategy');
-  console.log('    🏗️  rihal-waleed  — CTO');
-  console.log('    🛡️  rihal-fatima  — QA Lead');
-  console.log('');
-  console.log('  Slash commands installed:');
-  console.log('    /rihal:council  — parallel multi-agent council');
-  console.log('    /rihal:status   — project state dashboard');
-  console.log('    /rihal:insert-phase — insert decimal phase for urgent work');
+  console.log(`  Agents:    ${agentCount} installed in .claude/agents/  (e.g. rihal-sadiq, rihal-waleed, rihal-fatima)`);
+  console.log(`             Full roster: node .rihal/bin/rihal-tools.cjs list-agents`);
+  console.log(`  Commands:  ${commandCount} slash commands in .claude/commands/rihal/  (e.g. /rihal:council, /rihal:create-prd, /rihal:progress)`);
+  console.log(`             Full list:   ls .claude/commands/rihal/`);
+  if (skillsInstalled > 0) {
+    console.log(`  Skills:    ${skillsInstalled} phrase-activated in .claude/skills/`);
+  }
   console.log('');
   if (starterSeeded) {
     console.log('  ✓ Starter planning scaffolded in .planning/ (ROADMAP, STATE, PROJECT)');
@@ -1052,12 +1132,17 @@ async function install(opts) {
   }
   console.log('  Next:');
   console.log(`    cd ${opts.target}`);
-  console.log('    claude  # start Claude Code (or restart if already open)');
-  console.log('    /rihal:sprint-planning      # plan your first sprint');
-  console.log('    /rihal:do                   # interactive command picker');
-  console.log('    /rihal:council <question>   # multi-agent strategic answer');
+  console.log('    claude              # start Claude Code (reload window if already open)');
+  console.log('    /rihal:progress     # where you are, what\'s next');
+  console.log('    /rihal:do           # interactive command picker');
+  console.log('    /rihal:council <q>  # multi-agent strategic answer');
   console.log('');
-  console.log('  ⚠ If Claude Code is already running, start a new session to load commands.');
+  console.log('  Refresh anytime:');
+  console.log('    npx @hanzlaa/rcode@latest install   # pull the latest rcode + brain');
+  console.log('    /rihal:update v2.2.0                # pin rcode to a specific version');
+  console.log('');
+  console.log('  ⚠ If your IDE is already open, reload the window to refresh skills/commands.');
+  console.log('    Claude Code / VS Code / Cursor:  Cmd+Shift+P → Reload Window');
   console.log('');
   return 0;
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,6 +34,34 @@ Total install footprint: ~3.8 MB, 676 files.
 
 ---
 
+## What gets committed vs ignored
+
+On first install, rcode automatically updates your project's `.gitignore` so you commit the **work**, not the **methodology**. If you already have a `.gitignore`, rcode appends its block — your existing entries are preserved.
+
+| Path | Commit? | Why |
+|------|:-------:|-----|
+| `.rihal/config.yaml` | ✅ commit | Your project's chosen mode, language, profile — collaborators should see the same |
+| `.rihal/state.json` | ✅ commit | Decisions log, roadmap pointer, blockers — this is your project's memory |
+| `.planning/` | ✅ commit | PRD, roadmap, sprints, SUMMARY.md — the actual thinking |
+| `.claude/` | ❌ ignored | Installed skills/agents/commands — 500+ files, regenerate with `rcode install` |
+| `.rihal/bin/`, `.rihal/workflows/`, `.rihal/references/`, `.rihal/commands/`, `.rihal/skills/` | ❌ ignored | Methodology files — re-installed on every update |
+| `rihal/brain/` | ❌ ignored | Pulled Rihal standards — refresh with `rcode brain pull` |
+| `.rihal/state.json.lock`, `.planning/debug/`, `.planning/_backup/` | ❌ ignored | Runtime noise |
+
+**Without the auto-managed `.gitignore`**, `git add .` would bloat your repo by 676 files (~3.8 MB) — methodology files that regenerate on every install.
+
+The rcode block in `.gitignore` is marked with a sentinel comment:
+```
+# ===== rcode-managed gitignore block (npx @hanzlaa/rcode install) =====
+```
+Re-running install is idempotent — it detects the marker and skips re-appending. Safe to customize entries inside the block, but edits can be overwritten if you ever `sed` it out.
+
+### Manually commit everything anyway?
+
+Remove the rcode block from `.gitignore`. You own your repo. Just know that every `rcode update` will produce large diffs.
+
+---
+
 ## Pick your install flavor
 
 ### Default — full install, guided mode

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,6 +81,22 @@ Remove the rcode block from `.gitignore`. You own your repo. Just know that ever
 
 ---
 
+## Editor support matrix
+
+| Editor | `--ide` | What gets written | Status |
+|--------|---------|------------------|:------:|
+| Claude Code (CLI + desktop app) | `claude` *(default)* | `.claude/agents/`, `.claude/commands/rihal/`, `.claude/skills/` | ✅ v2.x |
+| Cursor | `cursor` | `.cursor/rules/rihal-*.mdc` | ✅ v2.x |
+| Gemini CLI | `gemini` | `.gemini/rihal/` | ✅ v2.x |
+| VS Code *with* Claude Code extension | `claude` | Same as Claude Code — extension reads `.claude/` | ✅ v2.x |
+| VS Code native (no Claude Code extension) | `vscode` | *not yet supported* | 🗓 v3.0 ([#182](https://github.com/hanzlahabib/rihal-code/issues/182)) |
+| JetBrains (IntelliJ / PyCharm) | `jetbrains` | *not yet supported* | 🗓 v3.0 ([#182](https://github.com/hanzlahabib/rihal-code/issues/182)) |
+| Zed | `zed` | *not yet supported* | 🗓 v3.0 ([#182](https://github.com/hanzlahabib/rihal-code/issues/182)) |
+
+Passing an unsupported `--ide` value prints a clear error with workaround guidance (e.g. VS Code users are pointed at `--ide claude` if they have the Claude Code extension).
+
+---
+
 ## Pick your install flavor
 
 ### Default — full install, guided mode

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,15 +38,34 @@ Total install footprint: ~3.8 MB, 676 files.
 
 On first install, rcode automatically updates your project's `.gitignore` so you commit the **work**, not the **methodology**. If you already have a `.gitignore`, rcode appends its block — your existing entries are preserved.
 
+Interactive installs also prompt you on `.planning/` specifically — you choose whether to commit PRDs, roadmaps, sprints, SUMMARY files (default yes) or keep them local (`--no-commit-planning`). You can flip this later at any time.
+
 | Path | Commit? | Why |
 |------|:-------:|-----|
-| `.rihal/config.yaml` | ✅ commit | Your project's chosen mode, language, profile — collaborators should see the same |
+| `.rihal/config.yaml` | ✅ commit | Your project's chosen mode, language, profile, commit_planning — collaborators should see the same |
 | `.rihal/state.json` | ✅ commit | Decisions log, roadmap pointer, blockers — this is your project's memory |
-| `.planning/` | ✅ commit | PRD, roadmap, sprints, SUMMARY.md — the actual thinking |
+| `.rihal/brain/sources.yaml` | ✅ commit | Brain source manifest — collaborators pull the same content |
+| `.planning/` | ✅ commit *(toggle-able)* | PRD, roadmap, sprints, SUMMARY.md — the actual thinking. Set `commit_planning: false` in config to gitignore instead. |
 | `.claude/` | ❌ ignored | Installed skills/agents/commands — 500+ files, regenerate with `rcode install` |
 | `.rihal/bin/`, `.rihal/workflows/`, `.rihal/references/`, `.rihal/commands/`, `.rihal/skills/` | ❌ ignored | Methodology files — re-installed on every update |
-| `rihal/brain/` | ❌ ignored | Pulled Rihal standards — refresh with `rcode brain pull` |
+| `.rihal/brain/rihal-github/`, `.rihal/brain/rihal-docs/`, `.rihal/brain/best-practices/` | ❌ ignored | Pulled Rihal standards — refresh with `rcode brain pull` |
 | `.rihal/state.json.lock`, `.planning/debug/`, `.planning/_backup/` | ❌ ignored | Runtime noise |
+
+### Flipping commit_planning after install
+
+If you want to change the commit policy for `.planning/` after install:
+
+```bash
+# Stop committing planning artifacts:
+node .rihal/bin/rihal-tools.cjs config-set commit_planning false
+node .rihal/bin/rihal-tools.cjs gitignore refresh
+
+# Start committing them again:
+node .rihal/bin/rihal-tools.cjs config-set commit_planning true
+node .rihal/bin/rihal-tools.cjs gitignore refresh
+```
+
+`gitignore refresh` reads `.rihal/config.yaml` and rewrites the rcode-managed block in `.gitignore`. It's idempotent — safe to run any time, and leaves your non-rcode gitignore entries untouched.
 
 **Without the auto-managed `.gitignore`**, `git add .` would bloat your repo by 676 files (~3.8 MB) — methodology files that regenerate on every install.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzlaa/rcode",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Rihal Code (rcode) — installable context-brain for Rihalians. 44 agents, 93 slash commands, 58 skills, pullable Rihal standards. Unified install for Claude Code, Cursor, and Gemini.",
   "main": "cli/index.js",
   "bin": {

--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -2805,8 +2805,26 @@ function cmdNotesCount() {
  */
 function cmdBrain(args) {
   const sub = args[0] || 'help';
-  const sourcesPath = path.join(PROJECT_ROOT, 'rihal', 'brain', 'sources.yaml');
-  const brainDir = path.join(PROJECT_ROOT, 'rihal', 'brain');
+  // sources.yaml lives under .rihal/brain/ in user installs (v2.2+).
+  // Older installs may have it at rihal/brain/ (pre-v2.2) — fall back for compat.
+  let sourcesPath = path.join(RIHAL_DIR, 'brain', 'sources.yaml');
+  let brainDir = path.join(RIHAL_DIR, 'brain');
+  if (!fs.existsSync(sourcesPath)) {
+    const legacyPath = path.join(PROJECT_ROOT, 'rihal', 'brain', 'sources.yaml');
+    if (fs.existsSync(legacyPath)) {
+      sourcesPath = legacyPath;
+      brainDir = path.join(PROJECT_ROOT, 'rihal', 'brain');
+    }
+  }
+
+  // Resolve a source's dest directory relative to brainDir.
+  // Accepts legacy absolute-looking values ("rihal/brain/rihal-github/") by
+  // stripping any leading "rihal/brain/" so the resolved path sits inside the
+  // chosen brainDir. New sources.yaml should use bare names ("rihal-github/").
+  function resolveDest(dest) {
+    const trimmed = String(dest || '').replace(/^rihal\/brain\//, '').replace(/^\/+/, '');
+    return path.join(brainDir, trimmed);
+  }
 
   if (!fs.existsSync(sourcesPath)) {
     return {
@@ -2913,7 +2931,7 @@ function cmdBrain(args) {
   if (sub === 'status') {
     const report = { ok: true, sources: [] };
     for (const s of sources) {
-      const destPath = path.join(PROJECT_ROOT, s.dest || '');
+      const destPath = resolveDest(s.dest);
       const exists = fs.existsSync(destPath);
       report.sources.push({
         name: s.name,
@@ -2947,7 +2965,7 @@ function cmdBrain(args) {
 
     if (repo === 'self') {
       // In-repo copy — use rsync-ish node copy from paths under project root.
-      const destPath = path.join(PROJECT_ROOT, s.dest);
+      const destPath = resolveDest(s.dest);
       fs.mkdirSync(destPath, { recursive: true });
       const paths = Array.isArray(s.paths) ? s.paths : [];
       let copied = 0;
@@ -2989,7 +3007,7 @@ function cmdBrain(args) {
       const paths = Array.isArray(s.paths) ? s.paths : [];
       execSync(`git -C "${tmp}" sparse-checkout set ${paths.map(p => `"${p}"`).join(' ')}`, { stdio: 'pipe' });
 
-      const destPath = path.join(PROJECT_ROOT, s.dest);
+      const destPath = resolveDest(s.dest);
       fs.mkdirSync(destPath, { recursive: true });
       // Copy everything the sparse checkout materialized.
       function copyTree(src, dst) {
@@ -3301,6 +3319,121 @@ function cmdStateSnapshot() {
   };
 }
 
+/**
+ * cmdGitignore — re-render the rcode-managed block in .gitignore based on
+ * current config (specifically commit_planning from .rihal/config.yaml).
+ *
+ * Subcommands:
+ *   gitignore refresh   rewrite the rcode block in-place
+ *   gitignore status    report current commit_planning + block presence
+ *
+ * Mirrors the logic in cli/install.js ensureRcodeGitignore — kept in sync
+ * by convention. Any change to the block format should update both.
+ * Closes #189 — runtime toggle for commit_planning.
+ */
+function cmdGitignore(args) {
+  const sub = args[0] || 'refresh';
+  const gitignorePath = path.join(PROJECT_ROOT, '.gitignore');
+  const configPath = path.join(RIHAL_DIR, 'config.yaml');
+
+  // Read commit_planning from config; default true if missing.
+  let commitPlanning = true;
+  if (fs.existsSync(configPath)) {
+    const cfg = fs.readFileSync(configPath, 'utf8');
+    const m = cfg.match(/^\s*commit_planning:\s*(true|false)\s*$/m);
+    if (m) commitPlanning = (m[1] === 'true');
+  }
+
+  const BEGIN = '# ===== rcode-managed gitignore block (npx @hanzlaa/rcode install) =====';
+  const END   = '# ===== end rcode-managed gitignore block =====';
+
+  if (sub === 'status') {
+    const exists = fs.existsSync(gitignorePath);
+    const hasBlock = exists && fs.readFileSync(gitignorePath, 'utf8').includes(BEGIN);
+    return {
+      ok: true,
+      gitignore_exists: exists,
+      block_present: hasBlock,
+      commit_planning: commitPlanning,
+    };
+  }
+
+  if (sub !== 'refresh') {
+    return { ok: false, error: `Unknown gitignore subcommand: ${sub}. Try: refresh | status` };
+  }
+
+  const lines = [
+    '',
+    BEGIN,
+    '# Added automatically on rcode install. Idempotent — safe to re-run.',
+    '# Edit `commit_planning` in .rihal/config.yaml, then: rihal-tools gitignore refresh',
+    '',
+    '# Installed methodology files (regenerate with: npx @hanzlaa/rcode install)',
+    '.claude/',
+    '.rihal/bin/',
+    '.rihal/workflows/',
+    '.rihal/references/',
+    '.rihal/commands/',
+    '.rihal/skills/',
+    '',
+    '# Pulled Rihal brain content (refresh with: rcode brain pull)',
+    '.rihal/brain/rihal-github/',
+    '.rihal/brain/rihal-docs/',
+    '.rihal/brain/best-practices/',
+    '',
+    '# Runtime noise',
+    '.rihal/state.json.lock',
+    '.planning/debug/',
+    '.planning/_backup/',
+  ];
+  if (!commitPlanning) {
+    lines.push('', '# Planning artifacts — kept local (commit_planning: false)', '.planning/');
+  }
+  lines.push(
+    '',
+    '# What you DO commit:',
+    '#   .rihal/config.yaml        - project mode/language/profile/commit_planning',
+    '#   .rihal/state.json         - decisions, roadmap pointer, blockers',
+    '#   .rihal/brain/sources.yaml - brain source manifest',
+    commitPlanning
+      ? '#   .planning/                - PRD, roadmap, sprints, SUMMARY.md files'
+      : '#   (planning artifacts are NOT committed — see commit_planning in config)',
+    END,
+    ''
+  );
+  const BLOCK = lines.join('\n');
+
+  /** Replace the rcode block in text using indexOf — safer than regex. */
+  function spliceBlock(existing, newBlock) {
+    const start = existing.indexOf(BEGIN);
+    if (start < 0) return null;
+    const endIdx = existing.indexOf(END, start);
+    if (endIdx < 0) return null;
+    // Include trailing newline after END if present, and leading newline before BEGIN.
+    let sliceStart = start;
+    if (sliceStart > 0 && existing[sliceStart - 1] === '\n') sliceStart -= 1;
+    let sliceEnd = endIdx + END.length;
+    if (existing[sliceEnd] === '\n') sliceEnd += 1;
+    return existing.slice(0, sliceStart) + newBlock + existing.slice(sliceEnd);
+  }
+
+  if (!fs.existsSync(gitignorePath)) {
+    fs.writeFileSync(gitignorePath, BLOCK);
+    return { ok: true, action: 'created', commit_planning: commitPlanning };
+  }
+  const existing = fs.readFileSync(gitignorePath, 'utf8');
+  if (existing.includes(BEGIN)) {
+    const rewritten = spliceBlock(existing, BLOCK);
+    if (rewritten !== null && rewritten !== existing) {
+      fs.writeFileSync(gitignorePath, rewritten);
+      return { ok: true, action: 'updated', commit_planning: commitPlanning };
+    }
+    return { ok: true, action: 'no-change', commit_planning: commitPlanning };
+  }
+  fs.writeFileSync(gitignorePath, existing + BLOCK);
+  return { ok: true, action: 'appended', commit_planning: commitPlanning };
+}
+
 function cmdFindFiles(rawArgs) {
   const flags = {};
   const parts = rawArgs.split(/\s+/).filter(p => p);
@@ -3453,6 +3586,10 @@ async function main() {
       }
       case 'state-snapshot': {
         result = cmdStateSnapshot();
+        break;
+      }
+      case 'gitignore': {
+        result = cmdGitignore(args);
         break;
       }
       case 'agent-skills':

--- a/rihal/brain/sources.yaml
+++ b/rihal/brain/sources.yaml
@@ -34,7 +34,7 @@ sources:
       - docs/issue-standards.md
       - docs/commit-standards.md
       - docs/review-checklist.md
-    dest: rihal/brain/rihal-github/
+    dest: rihal-github/
 
   - name: rihal-docs
     description: >
@@ -47,13 +47,16 @@ sources:
       - "guides/**/*.md"
       - "standards/**/*.md"
       - "playbooks/**/*.md"
-    dest: rihal/brain/rihal-docs/
+    dest: rihal-docs/
 
   - name: rihal-best-practices
     description: >
       Hanzla's one-year-of-usage best practices — in-repo, version-
-      controlled alongside the rest of Rihal Code.
+      controlled alongside the rest of Rihal Code. Resolved from the
+      installed .rihal/skills/_shared/ dir (or the package's own
+      rihal/skills/_shared/ when running inside the rihal-code repo).
     repo: self
     paths:
+      - .rihal/skills/_shared/**/*.md
       - rihal/skills/_shared/**/*.md
-    dest: rihal/brain/best-practices/
+    dest: best-practices/


### PR DESCRIPTION
Ships v2.2.0 installer polish milestone — 9 of 10 issues addressed, 1 deferred.

## Closes

- ✅ #187 — auto-managed .gitignore block (created in first commit of this PR)
- ✅ #188 — brain sources.yaml path fix (commit \`ffa0...\`)
- ✅ #189 — commit-planning toggle (GSD-style; install prompt + config + runtime flip)
- ✅ #190 — correct agent/command counts in summary
- ✅ #191 — version in banner + summary
- ✅ #192 — update hint in install summary
- ✅ #193 — post-install 5-point health check
- ✅ #195 — existing install detection banner
- ✅ #196 — orphan sweep on --force install (files-manifest.csv-based)
- ✅ #197 — structured error for unsupported --ide values (+ editor matrix in docs)

## Deferred (closed on GitHub with rationale)

- #194 — install progress feedback. Install is 1-2s; progress bars over-engineered for value. Reopen if feedback demands it.

## What the user sees now vs before

### Before
\`\`\`
🕌 Rihal Code installer → /tmp/x

  Installed: 360 files
  Skills:    56 phrase-activated
  Brain:     skipped (sources.yaml missing at /tmp/x/rihal/brain/sources.yaml)
  Gitignore: .gitignore created with rcode block

  Installed for IDE: claude
  ...
  Agents installed (first-class subagents):
    🧭 rihal-sadiq   — Director of Strategy
    🏗️  rihal-waleed  — CTO
    🛡️  rihal-fatima  — QA Lead

  Slash commands installed:
    /rihal:council  — parallel multi-agent council
    /rihal:status   — project state dashboard
    /rihal:insert-phase — insert decimal phase for urgent work
\`\`\`

### After
\`\`\`
🕌 Rihal Code v2.2.0 installer → /tmp/x
  ↻ Existing install at v2.1.0 — upgrading to v2.2.0 (config + state + .planning preserved).

  Files:     360 installed, 1 stale swept
  Brain:     1 source pulled, 2 skipped (placeholder URLs — see issue #162)
  Gitignore: .gitignore rcode block refreshed

  Version:   @hanzlaa/rcode@2.2.0
  IDE:       claude
  Language:  English
  Mode:      guided
  Profile:   balanced
  Planning:  committed  (flip: rihal-tools gitignore refresh)

  Agents:    44 installed in .claude/agents/
  Commands:  96 slash commands in .claude/commands/rihal/
  Skills:    56 phrase-activated in .claude/skills/

  Health check:
    ✓ rihal-tools.cjs runs — syntax ok
    ✓ .rihal/config.yaml present — 403 bytes
    ✓ .rihal/state.json parses — valid JSON
    ✓ agents installed — 44
    ✓ skills + commands installed — 56 + 96

  Refresh anytime:
    npx @hanzlaa/rcode@latest install
    /rihal:update v2.2.0

  ⚠ If your IDE is already open, reload the window.
\`\`\`

## Bumps version to 2.2.0

Package.json updated in first commit. Ready to \`npm publish\` after merge — user said hold on publish, so left for you to trigger when ready.

## Files changed

- \`cli/install.js\` — bulk of the changes
- \`rihal/bin/rihal-tools.cjs\` — new brain sources lookup, \`gitignore refresh\` subcommand
- \`rihal/brain/sources.yaml\` — simpler relative dest paths
- \`docs/install.md\` — commit-planning toggle section, editor support matrix
- \`CHANGELOG.md\` — v2.2.0 entry
- \`package.json\` — version 2.1.0 → 2.2.0