### PR TITLE
v2.3 — State integrity + installer hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Also bundles M2.5 (GSD-parity `/progress` and `/status` rebuild, PR #166) + the 
 
 ---
 
-## v2.0.0 — Rihal Brain (unreleased)
+## v2.0.0 — Rihal Brain (2026-04-23)
 
 **Repositioning release.** Rihal Code is no longer a generic AI-engineering methodology that happens to be written at Rihal. It is **the installable context-brain for Rihalians** — every Rihal project can now pull PR standards, commit conventions, architecture docs, and internal guides straight from Rihal's own repos into the AI assistant's context on install.
 

--- a/cli/install.js
+++ b/cli/install.js
@@ -74,6 +74,8 @@ function parseArgs(argv) {
     // #189 — planning commit policy. null = ask interactively (or default true under --yes).
     // Set true by --commit-planning, false by --no-commit-planning or --ignore-planning.
     commitPlanning: null,
+    // #199 — install the pre-commit hook (default true; opt out with --no-git-hooks).
+    gitHooks: true,
   };
   const positional = [];
   for (let i = 0; i < argv.length; i++) {
@@ -90,6 +92,8 @@ function parseArgs(argv) {
     else if (arg === '--module') opts.modules.push(argv[++i]);
     else if (arg === '--commit-planning') opts.commitPlanning = true;
     else if (arg === '--no-commit-planning' || arg === '--ignore-planning') opts.commitPlanning = false;
+    else if (arg === '--git-hooks') opts.gitHooks = true;
+    else if (arg === '--no-git-hooks') opts.gitHooks = false;
     else if (!arg.startsWith('--')) positional.push(arg);
   }
   if (positional[0]) {
@@ -420,6 +424,65 @@ function ensureRcodeGitignore(target, options = {}) {
  * Closes #188 — previously the package's rihal/brain/sources.yaml was never
  * copied to the target at all, leaving brain pull permanently broken.
  */
+/**
+ * Install a pre-commit git hook that auto-syncs state.json when .planning/
+ * or brain sources.yaml files are part of a commit (#199).
+ *
+ * Idempotent via a sentinel marker. User's existing pre-commit logic is
+ * preserved — we only append our block. Best-effort: never throws.
+ *
+ * Returns { action }: 'skipped-no-git' | 'created' | 'appended' | 'already-present' | 'skipped-error' | 'opted-out'
+ */
+function installPreCommitHook(target) {
+  const gitDir = path.join(target, '.git');
+  if (!fs.existsSync(gitDir) || !fs.statSync(gitDir).isDirectory()) {
+    return { action: 'skipped-no-git' };
+  }
+
+  const hookDir = path.join(gitDir, 'hooks');
+  const hookPath = path.join(hookDir, 'pre-commit');
+  const MARKER_BEGIN = '# ===== rcode-managed pre-commit block (state auto-sync) =====';
+  const MARKER_END = '# ===== end rcode-managed pre-commit block =====';
+
+  const block = [
+    '',
+    MARKER_BEGIN,
+    '# Auto-sync .rihal/state.json when .planning/ or brain sources.yaml change.',
+    '# Best-effort: never blocks a commit. Remove this block (or set git_hooks: false',
+    '# in .rihal/config.yaml + re-install) to opt out.',
+    'if git diff --cached --name-only | grep -qE "^\\.planning/|^\\.rihal/brain/sources\\.yaml$"; then',
+    '  if [ -x .rihal/bin/rihal-tools.cjs ] || [ -f .rihal/bin/rihal-tools.cjs ]; then',
+    '    node .rihal/bin/rihal-tools.cjs state sync --from-disk >/dev/null 2>&1 || true',
+    '    git add .rihal/state.json 2>/dev/null || true',
+    '  fi',
+    'fi',
+    MARKER_END,
+    '',
+  ].join('\n');
+
+  try {
+    fs.mkdirSync(hookDir, { recursive: true });
+
+    if (!fs.existsSync(hookPath)) {
+      fs.writeFileSync(hookPath, '#!/bin/sh\n' + block);
+      fs.chmodSync(hookPath, 0o755);
+      return { action: 'created' };
+    }
+
+    const existing = fs.readFileSync(hookPath, 'utf8');
+    if (existing.includes(MARKER_BEGIN)) {
+      return { action: 'already-present' };
+    }
+
+    // Append our block — preserve user's existing hook body.
+    fs.writeFileSync(hookPath, existing + block);
+    try { fs.chmodSync(hookPath, 0o755); } catch {}
+    return { action: 'appended' };
+  } catch (err) {
+    return { action: 'skipped-error', error: err.message };
+  }
+}
+
 function installBrainScaffold(packageRoot, target) {
   const srcDir = path.join(packageRoot, 'rihal', 'brain');
   const destDir = path.join(target, '.rihal', 'brain');
@@ -857,6 +920,7 @@ function generateConfigYaml(opts) {
     `mode: "${sanitizeYamlValue(opts.mode)}"`,
     `model_profile: "balanced"`,
     `commit_planning: ${opts.commitPlanning !== false}`,
+    `git_hooks: ${opts.gitHooks !== false}`,
     `rihal_source_path: "${sanitizeYamlValue(path.dirname(path.dirname(process.argv[1])))}/"`,
     'workflow:',
     '  research_by_default: false',
@@ -1078,6 +1142,10 @@ async function install(opts) {
   // Actual brain content lands after first brain pull runs.
   installBrainScaffold(PACKAGE_ROOT, opts.target);
 
+  // Install the pre-commit hook that auto-syncs state on .planning/ changes (#199).
+  // Opt-out via --no-git-hooks or git_hooks: false in config. Best-effort; never fails install.
+  const hookReport = opts.gitHooks !== false ? installPreCommitHook(opts.target) : { action: 'opted-out' };
+
   // Ensure .gitignore separates installed methodology from committable artifacts.
   // Reads opts.commitPlanning to decide whether .planning/ is in the ignore block.
   const gitignoreReport = ensureRcodeGitignore(opts.target, { commitPlanning: opts.commitPlanning });
@@ -1122,6 +1190,17 @@ async function install(opts) {
       'skipped-error': `.gitignore skipped (${gitignoreReport.error})`,
     }[gitignoreReport.action] || '.gitignore unchanged';
     console.log(`  Gitignore: ${gitMsg}`);
+  }
+  if (hookReport) {
+    const hookMsg = {
+      'created': 'pre-commit hook installed (auto-syncs state on .planning/ changes)',
+      'appended': 'pre-commit hook updated — rcode block appended',
+      'already-present': 'pre-commit hook already present',
+      'skipped-no-git': 'pre-commit hook skipped (no .git/ found)',
+      'skipped-error': `pre-commit hook skipped (${hookReport.error})`,
+      'opted-out': 'pre-commit hook skipped (--no-git-hooks)',
+    }[hookReport.action];
+    if (hookMsg) console.log(`  Git hook:  ${hookMsg}`);
   }
   if (skipped > 0) console.log(`  Skipped:   ${skipped} (already present, unchanged)`);
   if (opts.force && existedBefore) {

--- a/cli/uninstall.js
+++ b/cli/uninstall.js
@@ -549,6 +549,15 @@ async function runUninstall(args) {
     '.antigravity',
   ]);
 
+  // Always remove .rihal/brain/ — it's regenerable pulled content, not user state (#202).
+  // Keeps config.yaml + state.json + rest of .rihal/ for the separate state-delete flow below.
+  const brainDir = path.join(cwd, '.rihal', 'brain');
+  if (fs.existsSync(brainDir)) {
+    fs.rmSync(brainDir, { recursive: true, force: true });
+    console.log(`   ✓ removed .rihal/brain/ (pulled content — regenerable via brain pull)`);
+    removed += 1;
+  }
+
   // Handle .rihal/ state directory
   if (plan.stateDir) {
     const rihalDir = path.join(cwd, '.rihal');

--- a/rihal/skills/actions/2-plan/rihal-create-epics-and-stories/workflow.md
+++ b/rihal/skills/actions/2-plan/rihal-create-epics-and-stories/workflow.md
@@ -4,6 +4,18 @@
 
 **Your Role:** In addition to your name, communication_style, and persona, you are also a product strategist and technical specifications writer collaborating with a product owner. This is a partnership, not a client-vendor relationship. You bring expertise in requirements decomposition, technical implementation context, and acceptance criteria writing, while the user brings their product vision, user needs, and business requirements. Work together as equals.
 
+## State-sync rule (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, epics.md, sprint-*.md, SUMMARY.md, etc.) or updates phase/story status:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+This keeps `.rihal/state.json` in sync with disk — `/rihal:progress`, `/rihal:status`, and `/rihal:execute` all read state.json. Skipping the sync silently drifts them. See `../../_shared/state-sync-rule.md`.
+
+---
+
 ---
 
 ## WORKFLOW ARCHITECTURE

--- a/rihal/skills/actions/4-implementation/rihal-dev-story/workflow.md
+++ b/rihal/skills/actions/4-implementation/rihal-dev-story/workflow.md
@@ -3,6 +3,19 @@
 **Goal:** Execute story implementation following a context filled story spec file.
 
 **Your Role:** Developer implementing the story.
+
+## State-sync rule (NO EXCEPTIONS)
+
+After this workflow writes any SUMMARY.md, updates a story status in epics.md, or marks a phase complete:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+This keeps `.rihal/state.json` in sync with disk — `/rihal:progress`, `/rihal:status`, and `/rihal:execute` all read state.json. Skipping the sync silently drifts them. See `../../_shared/state-sync-rule.md`.
+
+---
+
 - Communicate all responses in {communication_language} and language MUST be tailored to {user_skill_level}
 - Generate all documents in {document_output_language}
 - Only modify the story file in these areas: Tasks/Subtasks checkboxes, Dev Agent Record (Debug Log, Completion Notes), File List, Change Log, and Status

--- a/rihal/skills/actions/4-implementation/rihal-retrospective/workflow.md
+++ b/rihal/skills/actions/4-implementation/rihal-retrospective/workflow.md
@@ -3,6 +3,18 @@
 **Goal:** Post-epic review to extract lessons and assess success.
 
 **Your Role:** Scrum Master facilitating retrospective.
+
+## State-sync rule (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, epics.md, sprint-*.md, SUMMARY.md, etc.) or updates phase/story status:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+This keeps `.rihal/state.json` in sync with disk — `/rihal:progress`, `/rihal:status`, and `/rihal:execute` all read state.json. Skipping the sync silently drifts them. See `../../_shared/state-sync-rule.md`.
+
+---
 - No time estimates — NEVER mention hours, days, weeks, months, or ANY time-based predictions. AI has fundamentally changed development speed.
 - Communicate all responses in {communication_language} and language MUST be tailored to {user_skill_level}
 - Generate all documents in {document_output_language}

--- a/rihal/skills/actions/4-implementation/rihal-sprint-planning/workflow.md
+++ b/rihal/skills/actions/4-implementation/rihal-sprint-planning/workflow.md
@@ -4,6 +4,18 @@
 
 **Your Role:** You are a Scrum Master generating and maintaining sprint tracking. Parse epic files, detect story statuses, and produce a structured sprint-status.yaml.
 
+## State-sync rule (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, epics.md, sprint-*.md, SUMMARY.md, etc.) or updates phase/story status:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+This keeps `.rihal/state.json` in sync with disk — `/rihal:progress`, `/rihal:status`, and `/rihal:execute` all read state.json. Skipping the sync silently drifts them. See `../../_shared/state-sync-rule.md`.
+
+---
+
 ---
 
 ## CRITICAL RULES (NO EXCEPTIONS)

--- a/rihal/team.yaml
+++ b/rihal/team.yaml
@@ -341,3 +341,252 @@ routing:
     - rihal-hussain-pm  # scope
     - rihal-waleed      # feasibility
     - rihal-sadiq       # strategic fit
+
+  # ===== Tactical sub-agents (spawned by slash commands / workflows) =====
+  # These are orchestration helpers, not council-facing first-class agents.
+  # Added 2026-04-24 to close team.yaml/disk divergence (#201).
+
+  - id: rihal-advisor-researcher
+    name: Advisor Researcher
+    file_path: rihal/agents/rihal-advisor-researcher.md
+    role: Gray-area decision researcher
+    authority_level: operational
+    domain_keywords:
+      - decision-research
+      - comparison-table
+      - tradeoff-analysis
+
+  - id: rihal-architect
+    name: Architect
+    file_path: rihal/agents/rihal-architect.md
+    role: Enterprise Architecture & System Design
+    authority_level: technical
+    domain_keywords:
+      - architecture
+      - system-design
+      - scalability
+      - integration
+
+  - id: rihal-assumptions-analyzer
+    name: Assumptions Analyzer
+    file_path: rihal/agents/rihal-assumptions-analyzer.md
+    role: Codebase assumption surfacer
+    authority_level: operational
+    domain_keywords:
+      - assumptions
+      - discuss-phase
+      - evidence-gathering
+
+  - id: rihal-codebase-mapper
+    name: Codebase Mapper
+    file_path: rihal/agents/rihal-codebase-mapper.md
+    role: Codebase exploration + structured analysis
+    authority_level: operational
+    domain_keywords:
+      - codebase-analysis
+      - tech-stack
+      - architecture-discovery
+
+  - id: rihal-code-fixer
+    name: Code Fixer
+    file_path: rihal/agents/rihal-code-fixer.md
+    role: Code fix specialist — applies review findings
+    authority_level: technical
+    domain_keywords:
+      - code-fix
+      - refactor
+      - style
+
+  - id: rihal-code-reviewer
+    name: Code Reviewer
+    file_path: rihal/agents/rihal-code-reviewer.md
+    role: Code review specialist — architectural + quality assessment
+    authority_level: quality
+    domain_keywords:
+      - code-review
+      - quality
+      - security
+      - tests
+
+  - id: rihal-debugger
+    name: Debugger
+    file_path: rihal/agents/rihal-debugger.md
+    role: Scientific-method bug investigation
+    authority_level: technical
+    domain_keywords:
+      - bug
+      - debug
+      - investigation
+      - checkpoint
+
+  - id: rihal-deviation-analyzer
+    name: Deviation Analyzer
+    file_path: rihal/agents/rihal-deviation-analyzer.md
+    role: Plan-deviation root cause analyst
+    authority_level: operational
+    domain_keywords:
+      - deviation
+      - scope-creep
+      - remediation
+
+  - id: rihal-docs-auditor
+    name: Docs Auditor
+    file_path: rihal/agents/rihal-docs-auditor.md
+    role: Documentation completeness + accuracy audit
+    authority_level: quality
+    domain_keywords:
+      - docs-audit
+      - completeness
+      - accuracy
+
+  - id: rihal-edge-case-hunter
+    name: Edge Case Hunter
+    file_path: rihal/agents/rihal-edge-case-hunter.md
+    role: Enumerate edge cases + boundary conditions
+    authority_level: quality
+    domain_keywords:
+      - edge-cases
+      - boundary-conditions
+      - corner-cases
+      - defensive-coding
+
+  - id: rihal-integration-checker
+    name: Integration Checker
+    file_path: rihal/agents/rihal-integration-checker.md
+    role: Cross-phase integration + E2E flow verifier
+    authority_level: quality
+    domain_keywords:
+      - integration
+      - e2e
+      - cross-phase
+
+  - id: rihal-nyquist-auditor
+    name: Nyquist Auditor
+    file_path: rihal/agents/rihal-nyquist-auditor.md
+    role: Validation-gap auditor (Nyquist coverage)
+    authority_level: quality
+    domain_keywords:
+      - validation
+      - test-coverage
+      - nyquist-gap
+
+  - id: rihal-phase-researcher
+    name: Phase Researcher
+    file_path: rihal/agents/rihal-phase-researcher.md
+    role: Pre-plan research producer (RESEARCH.md)
+    authority_level: operational
+    domain_keywords:
+      - phase-research
+      - prior-art
+      - evaluation
+
+  - id: rihal-profiler
+    name: Profiler
+    file_path: rihal/agents/rihal-profiler.md
+    role: User behavior / persona profiler
+    authority_level: product
+    domain_keywords:
+      - personas
+      - usage-patterns
+      - user-behavior
+
+  - id: rihal-project-researcher
+    name: Project Researcher
+    file_path: rihal/agents/rihal-project-researcher.md
+    role: Domain ecosystem researcher for roadmap inputs
+    authority_level: operational
+    domain_keywords:
+      - domain-research
+      - ecosystem
+      - roadmap-inputs
+
+  - id: rihal-remediation-planner
+    name: Remediation Planner
+    file_path: rihal/agents/rihal-remediation-planner.md
+    role: Issue + blocker remediation planner
+    authority_level: operational
+    domain_keywords:
+      - remediation
+      - unblocking
+      - recovery-plan
+
+  - id: rihal-research-synthesizer
+    name: Research Synthesizer
+    file_path: rihal/agents/rihal-research-synthesizer.md
+    role: Parallel-researcher output synthesizer
+    authority_level: operational
+    domain_keywords:
+      - synthesis
+      - aggregation
+      - research-consolidation
+
+  - id: rihal-roadmapper
+    name: Roadmapper
+    file_path: rihal/agents/rihal-roadmapper.md
+    role: Roadmap builder — phase + requirement + acceptance coverage
+    authority_level: product
+    domain_keywords:
+      - roadmap
+      - phases
+      - requirements-mapping
+
+  - id: rihal-security-adversary
+    name: Security Adversary
+    file_path: rihal/agents/rihal-security-adversary.md
+    role: Adversarial security review + threat modelling
+    authority_level: quality
+    domain_keywords:
+      - security
+      - threat-model
+      - adversarial
+      - attack-surface
+
+  - id: rihal-security-auditor
+    name: Security Auditor
+    file_path: rihal/agents/rihal-security-auditor.md
+    role: Comprehensive security audit + compliance verification
+    authority_level: quality
+    domain_keywords:
+      - security-audit
+      - compliance
+      - remediation
+
+  - id: rihal-sprint-checker
+    name: Sprint Checker
+    file_path: rihal/agents/rihal-sprint-checker.md
+    role: Sprint goal-backward verifier before execution
+    authority_level: quality
+    domain_keywords:
+      - sprint-check
+      - goal-backward
+      - pre-execute-gate
+
+  - id: rihal-ui-auditor
+    name: UI Auditor
+    file_path: rihal/agents/rihal-ui-auditor.md
+    role: UI usability + consistency + accessibility audit
+    authority_level: design
+    domain_keywords:
+      - ui-audit
+      - accessibility
+      - design-consistency
+      - usability
+
+  - id: rihal-ui-designer
+    name: UI Designer (alias for rihal-ux-designer)
+    file_path: rihal/agents/rihal-ui-designer.md
+    role: Alias — see rihal-ux-designer
+    authority_level: design
+    domain_keywords:
+      - ui-design
+
+  - id: rihal-ux-designer
+    name: UX Designer
+    file_path: rihal/agents/rihal-ux-designer.md
+    role: UX design + interaction design + accessibility
+    authority_level: design
+    domain_keywords:
+      - ux
+      - interaction-design
+      - accessibility
+      - user-flows


### PR DESCRIPTION
Closes #198 (partial), #199, #201, #202, #203. Defers #200 (strict drift mode) and #204 (rihal-tools.cjs split) for a later iteration.

## Problem

Audit found a drift vector in the skill → state.json relationship:

- Only \`rihal-create-milestone\` called \`state sync --from-disk\` on completion.
- Every other skill that writes to \`.planning/\` silently left state.json drifting.
- Result: \`/rihal:status\`, \`/rihal:progress\`, \`/rihal:execute\` read stale state. New agents unreachable via \`/rihal:council\` because team.yaml divergence.

## What landed

### State integrity (#198 + #199)

- **Pre-commit hook** auto-syncs state.json when \`.planning/\` or brain sources.yaml change in a commit. Idempotent via sentinel. Best-effort (|| true) — never blocks commits. \`--git-hooks\` / \`--no-git-hooks\` to control.
- **Skill-level rule** added to 4 highest-impact workflows that write \`.planning/\` artifacts: \`rihal-dev-story\`, \`rihal-sprint-planning\`, \`rihal-retrospective\`, \`rihal-create-epics-and-stories\`. Each references the shared rule.
- Install config gains \`git_hooks: true\`.

### team.yaml divergence closed (#201)

- Added 24 tactical sub-agents previously missing from team.yaml.
- \`grep "^  - id:" rihal/team.yaml | wc -l\` now equals \`ls rihal/agents/*.md | wc -l\` (both 44).
- Council dispatch + \`/rihal:do\` routing can now route to every installed agent.

### Uninstall cleanup (#202)

- \`.rihal/brain/\` removed on every uninstall (regenerable content, not user state).
- \`.rihal/config.yaml\` + \`.rihal/state.json\` still require \`--delete-state\` confirmation.

### CHANGELOG cleanup (#203)

- v2.0.0 entry was labelled \`(unreleased)\` despite being live on npm since April 23. Corrected to the actual release date.

### Closed as non-gap

- #205 — rihal/commands/report.md is an intentional alias (@-includes session-report.md), not an orphan. Audit script had a false positive on alias commands.

## Deferred to follow-ups (tracked, not in this PR)

- **#200** — strict drift mode in /rihal:status (env flag to fail hard on drift). Soft warning is enough until #198 + #199 settle.
- **#204** — split rihal-tools.cjs (3691 lines) into lib/ modules. Substantial refactor; deserves its own PR with full test matrix.
- **#198 remaining skills** — verify-phase, secure-phase, validate-phase, plan-phase mostly orchestrate rather than write; pre-commit hook catches any escape. Will sweep if real-world drift shows up.

## Verification

- Fresh install → \`.git/hooks/pre-commit\` installed with sentinel.
- Edit ROADMAP.md → commit → hook runs, state.json regenerated + auto-staged in the same commit.
- Re-run install → hook already present → idempotent.
- \`grep "State-sync rule" rihal/skills/actions/**/*workflow.md\` → 4 files (target skills).
- \`grep "^  - id:" rihal/team.yaml | wc -l\` → 44 (was 20).
- Uninstall on a project with brain content → \`.rihal/brain/\` removed; config + state preserved unless --delete-state.

## Not published yet

Holding for user review before \`npm publish\`. This is a minor version bump candidate (v2.3.0) but package.json still reads 2.2.0 — bump on merge or as a separate commit.