### PR TITLE
v2.4 batch 1: methodology integrity — close interpos-style bypass

### DIFF
--- a/rihal/workflows/autonomous.md
+++ b/rihal/workflows/autonomous.md
@@ -4,15 +4,82 @@ Drive milestone phases autonomously — all remaining phases, a range via `--fro
 
 </purpose>
 
+<critical_rules priority="absolute">
+
+These rules apply throughout autonomous execution. Violations broke the
+interpos audit (issue #221) — DO NOT regress.
+
+1. **NEVER modify `.rihal/config.yaml`.** Specifically: never write
+   `mode: yolo`, never call `rihal-tools config-set mode`, never `sed`
+   the file. The user's mode preference is sacred. Autonomous behavior
+   is governed by the workflow's own internal flags + the `--auto`
+   invocation flag, NOT by mutating persistent config.
+
+2. **NEVER skip the methodology chain on greenfield projects.** Before
+   the phase loop runs, the prerequisite check (next step) MUST verify:
+   - `.planning/prd.md` exists (else halt → /rihal:create-prd)
+   - ROADMAP.md has milestone structure (else halt → /rihal:create-milestone)
+   - `.planning/epics.md` exists (else halt → /rihal:create-epics-and-stories)
+   See issue #219 + #229.
+
+3. **NEVER write SPRINT.md directly.** Sprint creation MUST go through
+   the `rihal-sprint-planning` skill so the capacity gate (#127) fires.
+   If autonomous needs a sprint, invoke the skill — don't shortcut.
+
+4. **ALWAYS call `state sync --from-disk` after writing any
+   .planning/ artifact.** Otherwise state.json drifts and downstream
+   workflows lie. See `_shared/state-sync-rule.md` (#198).
+
+5. **ALWAYS record decisions via `rihal-tools state add-decision`.**
+   Never write decision prose to STATE.md. See #224.
+
+</critical_rules>
+
 <required_reading>
 
 @.rihal/references/output-format.md
 @.rihal/references/workstream-flag.md
 @.rihal/references/output-realism.md
+@.rihal/skills/_shared/no-autonomous-bypass.md
+@.rihal/skills/_shared/state-sync-rule.md
 
 Read all files referenced by the invoking prompt's execution_context before starting.
 
 </required_reading>
+
+<step name="prerequisite_check" priority="before-everything">
+
+## 0. Prerequisite check (greenfield guard)
+
+Before any phase work, verify the methodology chain has run:
+
+```bash
+HAS_PRD=$([ -f .planning/prd.md ] && echo true || echo false)
+HAS_ROADMAP_MILESTONES=$(grep -qE "^## Milestone\s+M[0-9]+" .planning/ROADMAP.md 2>/dev/null && echo true || echo false)
+HAS_EPICS=$([ -f .planning/epics.md ] && echo true || echo false)
+SKIP_FLAG=$(echo "$ARGUMENTS" | grep -qE "\-\-skip-prerequisites" && echo true || echo false)
+```
+
+If `SKIP_FLAG=false` AND any prerequisite is missing, HALT with a clear message:
+
+```
+⚠ Cannot run autonomous: missing prerequisite — {what}.
+
+The autonomous flow assumes a project that has already gone through:
+  1. /rihal:create-prd               → produces .planning/prd.md
+  2. /rihal:create-milestone         → produces ROADMAP.md with M1..Mn
+  3. /rihal:create-epics-and-stories → produces .planning/epics.md
+  4. THEN /rihal:autonomous           ← you are here
+
+Suggested first step: /rihal:{first-missing-command}
+
+If you genuinely want to skip these (rare — usually inverted methodology),
+re-invoke with: /rihal:autonomous --skip-prerequisites
+```
+
+If `SKIP_FLAG=true`: print a warning that downstream workflows may produce low-quality output without upstream artifacts, then proceed.
+
+</step>
 
 <output_format>
 

--- a/rihal/workflows/do.md
+++ b/rihal/workflows/do.md
@@ -52,17 +52,52 @@ If user picks 1-15, invoke that command. If 16, capture text and continue.
 </step>
 
 <step name="check_project">
-**Check if project exists.**
+**Check if project exists + state survey.**
 
 ```bash
 INIT=$(node ".rihal/bin/rihal-tools.cjs" state load 2>/dev/null)
+HAS_PRD=$([ -f .planning/prd.md ] && echo true || echo false)
+HAS_EPICS=$([ -f .planning/epics.md ] && echo true || echo false)
+PHASE_COUNT=$(node ".rihal/bin/rihal-tools.cjs" progress init 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin).get('phase_count',0))" 2>/dev/null || echo 0)
+HAS_PHASES=$([ "$PHASE_COUNT" -gt 0 ] && echo true || echo false)
 ```
 
-Track whether `.planning/` exists — some routes require it, others don't.
+These flags drive the greenfield guard in the next step. `.planning/` existing alone is not enough — we need to know whether the methodology chain has actually run (PRD → milestone → epics → phases).
+</step>
+
+<step name="greenfield_guard" priority="first-match">
+**Block methodology inversion.**
+
+Some routes ASSUME upstream artifacts exist. If they don't, dispatching to them inverts the chain (the autonomous-bypass pattern that produced the interpos disaster — issue #220 + #219).
+
+Apply this guard BEFORE the routing table below:
+
+| Intent contains... | AND state shows... | Then re-route to... | Why |
+|--------------------|---------------------|----------------------|-----|
+| "draft phases", "all phases", "build all phases", "groom phases", "auto mode" + "phases" | `HAS_PRD=false` | `/rihal:create-prd` first | Phases need a PRD foundation. Without one, the autonomous flow hallucinates requirements. |
+| "execute phase", "build phase N", "run phase N" | `HAS_PHASES=false` OR PLAN.md missing for phase N | `/rihal:plan N` first (or `/rihal:create-prd` if no PRD) | Can't execute what hasn't been planned. |
+| "sprint planning", "plan the sprint" | `HAS_EPICS=false` | `/rihal:create-epics-and-stories` first | Sprints draw stories from epics. No epics = no stories to schedule. |
+| "create stories", "epics" | `HAS_PRD=false` | `/rihal:create-prd` first | Epics decompose a milestone. Milestone needs PRD. |
+| "create milestones", "roadmap" | `HAS_PRD=false` | `/rihal:create-prd` first | Roadmap is derived from PRD success metrics. |
+
+When the guard fires, print a clear message:
+
+```
+⚠ Cannot {requested action}: missing prerequisite — {what's missing}.
+
+Re-routing to: /rihal:{prerequisite-command}
+Once that completes, re-run your original request.
+```
+
+Then dispatch to the prerequisite command instead of the originally-matched route.
+
+The guard never silently rejects intent — it always either dispatches to a sensible alternative OR explicitly tells the user what flag overrides it (e.g. `--skip-prerequisites` for the rare legitimate use case).
 </step>
 
 <step name="route">
 **Match intent to command.**
+
+(Run only after greenfield_guard has cleared.)
 
 Evaluate `$QUESTION` against these routing rules. Apply the **first matching** rule:
 

--- a/rihal/workflows/sprint-planning.md
+++ b/rihal/workflows/sprint-planning.md
@@ -1,10 +1,45 @@
 # Workflow: rihal:sprint-planning
 
 <purpose>
-Plan the next sprint: compute capacity from velocity history, prioritize stories from phase scope, create SPRINT.md, register sprint + stories in state.json.
+Plan the next sprint. Authoritative implementation lives in the
+`rihal-sprint-planning` skill — this workflow delegates to it so every
+safety rail (capacity gate per #127, halt-at-menu per #124, state-sync
+per #198) fires identically whether the user invokes the slash command
+or the phrase-activated skill.
 
-Uses rihal-tools.cjs sprint/story state commands for tracking.
+The skill MUST be loaded before the in-line steps below run. If the skill
+file is missing (broken install), report and stop — do not silently fall
+back to the in-line implementation.
 </purpose>
+
+<delegate_to_skill>
+Required skill: `rihal-sprint-planning`
+Path:           `.claude/skills/rihal-sprint-planning/SKILL.md`
+Workflow ref:   `.claude/skills/rihal-sprint-planning/workflow.md`
+
+Behaviour:
+1. Load the skill's `SKILL.md` and `workflow.md`. Apply every Critical
+   Rule from the workflow's `## CRITICAL RULES (NO EXCEPTIONS)` block,
+   including the capacity gate (step n="0") which MUST halt for
+   numeric capacity inputs before any story is committed.
+2. Run the skill's step files in order. The in-line steps below this
+   block are a fallback summary for legacy installs that lack the skill;
+   they are NOT the authoritative behaviour.
+3. After SPRINT.md is written, ALWAYS run:
+   `node .rihal/bin/rihal-tools.cjs state sync --from-disk`
+   so state.sprints[] reflects the new sprint.
+
+If skill files are missing: print
+"Sprint-planning skill not installed. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps because
+they bypass the capacity gate.
+</delegate_to_skill>
+
+<required_reading>
+@.rihal/references/output-format.md
+@.rihal/skills/_shared/no-autonomous-bypass.md
+@.rihal/skills/_shared/state-sync-rule.md
+</required_reading>
 
 <output_format>
 Open with banner:
@@ -13,14 +48,10 @@ Open with banner:
  RIHAL ► PLANNING SPRINT
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
-TaskCreate: "Load phase scope + velocity", "Curate stories with user", "Register sprint + stories in state", "Write SPRINT.md", "Start sprint".
+TaskCreate: "Load phase scope + velocity", "Capacity gate (halt for numbers)", "Curate stories with user", "Register sprint + stories in state", "Write SPRINT.md", "Sync state", "Start sprint".
 Closure: `RIHAL ► SPRINT {NN.S} READY ✓ ({N} stories, {M} points)`
 Next Up: `/rihal:execute .planning/phases/{phase}/SPRINT.md`
 </output_format>
-
-<required_reading>
-@.rihal/references/output-format.md
-</required_reading>
 
 <process>
 ## Step 0 — Usage check


### PR DESCRIPTION
First batch of v2.4 milestone fixes — the four highest-leverage gaps from the interpos audit.

## Closes

- #218 (sprint-planning skill delegation — partial; one workflow done, rest deferred to follow-up)
- #219 (autonomous prerequisite check)
- #220 (router greenfield guard)
- #221 (no silent mode flip)
- #229 (autonomous chain wiring)

## What this prevents

The interpos audit found that a single \`/rihal:do auto mode draft all phases\` dispatch produced:
- 7 phases without a PRD foundation
- ROADMAP.md hand-typed instead of generated by \`rihal-create-milestone\`
- Zero epics.md
- All 7 SPRINT.md files with \`Capacity: TBD / TBD\` (capacity gate bypassed)
- \`mode: yolo\` silently written to config.yaml
- \`state.epics\` key missing entirely

After this PR:
- \`/rihal:do\` greenfield guard blocks the inversion at the router layer.
- \`/rihal:autonomous\` prerequisite check blocks it at the workflow layer.
- \`autonomous.md\` Critical Rules block forbids \`.rihal/config.yaml\` mutation.
- Sprint-planning workflow delegates to its skill, so the capacity gate fires regardless of slash-command vs phrase invocation.

## Out of scope (filed, not in this PR)

8 more v2.4 tickets remain open. They're mechanical follow-ups:
- #222 STATE.md vs state.json SSOT
- #223 state-sync sweep across 18 workflows
- #224 decisions → \`state add-decision\` CLI
- #225 /rihal:execute prerequisite check
- #226 /rihal:new-project chain orchestration
- #227 duplicate sync paths
- #228 54 dangling slash-command refs
- #218 remainder — 7 more workflow→skill delegations

Each is small. Each can land as its own PR. Want to keep this PR focused on the highest-leverage four.

## Verification

- \`grep "delegate_to_skill" rihal/workflows/sprint-planning.md\` → returns the new block.
- \`grep "greenfield_guard" rihal/workflows/do.md\` → returns the new step.
- \`grep "NEVER modify .rihal/config.yaml" rihal/workflows/autonomous.md\` → returns the rule.
- \`grep "prerequisite_check" rihal/workflows/autonomous.md\` → returns the step.

E2E test (manual, in scratch dir):
\`\`\`
mkdir /tmp/v24-test && cd /tmp/v24-test
npx @hanzlaa/rcode install --yes
# (no PRD, no roadmap, no epics)
# → /rihal:do "auto mode draft all phases" should halt and route to /rihal:create-prd
# → /rihal:autonomous should halt with prerequisite error
# → /rihal:sprint-planning should halt at capacity gate (via skill delegation)
\`\`\`