### PR TITLE
v2.4 batch 2: close remaining methodology integrity gaps

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,79 +1,31 @@
-# Rihal Code — State
+# rihal-code — State
 
-**Last updated:** 2026-04-16
+**Last rendered:** 2026-04-25
+**Source of truth:** `.rihal/state.json` (this file is auto-generated; do not edit by hand)
 **Milestone:** M1 — Ship v2 + Tier Docs
-**Version:** 1.0.0-beta.0
-**Current phase:** 04 — Template Improvements (next to start)
-**Branch:** main
-
----
-
-## Completed
-
-### Phase 01 — Tier-based Documentation Reorg ✅ (2026-04-15)
-- TIERS.md, STANDARDS.md, V2-PREVIEW.md
-- README "Start Here" block + `rihal-code tiers` command + grouped help
-
-### Phase 02 — Scaffold Project Skill ✅ (2026-04-15)
-- `rihal-scaffold-project` (4-step workflow)
-- GH issue #101 for template improvements
-
-### Phase 03 — V2 Stabilization ✅ (2026-04-15/16)
-- v1/v2 merged into single `rihal/` root (v2 folder eliminated)
-- Unified installer: `cli/install.js` (70 cmd + 34 agents + 39 skills)
-- Ghost v1 agents purged (model-profiles, 14 orphan digests)
-- 5 bloated agents slim-split (#103-#107)
-- Docs agents consolidated — 2 aliases deleted (#108)
-- new-project.md split to 3 files (#102)
-- BMAD/GSD history rewrite (95 commits)
-- output-realism.md reference added
-- Version bumped to 1.0.0-beta.0
-- Clean sweep: zero broken refs, 95/95 tests
-
-### Additional work (not in original roadmap)
-- 8 GH issues created and 7 closed (#102-#109)
-- #110 created: Phase → Sprint → Story/Task hierarchy (future milestone)
-- Sprint-planning workflow added (was missing)
-- SKILLS_INDEX cleaned (2 bogus v1 refs removed)
-- CHANGELOG v1.0.0-beta.0 release notes written
-
----
-
-## In Progress
-
-None.
+**Current phase:** 04
 
 ---
 
 ## Decisions
 
-- **v1/v2 merged.** Single `rihal/` root. No more v2-prototype branch. `cli/install.js` is the only installer.
-- **`.planning/` stays separate from `.rihal/`.** User artifacts vs system infra. Confirmed 2026-04-16.
-- **Phase → Sprint → Story/Task hierarchy change** → deferred to future milestone (#110). Current NN.MM.TT numbering stays for now.
-- **Force-push authorized one-time** (2026-04-15) for history rewrite. Not blanket auth.
-- **Template repo stays external.** `rihal-scaffold-project` always clones fresh.
-- **Tier doc is canonical.** `docs/TIERS.md` is single source of truth.
-- **Fresh install command:** `git clone --depth 1 ... /tmp/rihal-src && node /tmp/rihal-src/cli/install.js . && rm -rf /tmp/rihal-src`
-
----
+- **2026-04-17** test A — cross-project memory from rihal-code
+- **2026-04-17** test B — second decision
+- **2026-04-17** post-edit sanity check
 
 ## Blockers
 
-None.
+_None._
+
+## Phases
+
+- **[01]** Tier-based Documentation Reorg — _complete_
+- **[02]** Scaffold Project Skill — _complete_
+- **[03]** V2 Stabilization — _complete_
+- **[04]** Dashboard Refresh — _planned_
+- **[05]** Marketing + Launch — _planned_
 
 ---
 
-## Open GH Issues
-
-| # | Title | Priority |
-|---|-------|----------|
-| #101 | Template improvements (pnpm, .rihal/config, Node 20+, gitignore) | p2 |
-| #110 | Phase → Sprint → Story/Task hierarchy (remove Plan level) | p2 |
-
----
-
-## Next Action
-
-Start Phase 04 (Template Improvements) — audit `rihal-om/template`, open PRs for each improvement in #101.
-
-Or start Phase 05 (Dashboard Refresh) if template work is lower priority.
+_Re-render: `node .rihal/bin/rihal-tools.cjs state render`_
+_Add a decision: `node .rihal/bin/rihal-tools.cjs state add-decision "<text>"`_

--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -1661,8 +1661,14 @@ function cmdState(subArgs) {
     return result;
   }
 
-  // --- set-ids-in-state ---
+  // --- set-ids-in-state (DEPRECATED per #227) ---
+  // Kept for backward compatibility. New callers should use `state sync --from-disk`.
   if (sub === 'set-ids-in-state') {
+    process.stderr.write(
+      '\x1b[33m⚠ DEPRECATED:\x1b[0m `state set-ids-in-state` is superseded by ' +
+      '`state sync --from-disk` (#227). It will be removed in v3.0.\n' +
+      '  Migrate: replace any script calls with `node .rihal/bin/rihal-tools.cjs state sync --from-disk`\n\n'
+    );
     const state = readState() || defaultState();
     if (!state.phases) state.phases = [];
     if (!state.plans) state.plans = [];
@@ -2173,7 +2179,87 @@ function cmdState(subArgs) {
     return { ok: true, synced: true, ...parsed };
   }
 
-  throw new Error(`Unknown state subcommand: ${sub}.\nCommon: read, set-phase, advance-plan, add-decision, decisions-global, add-blocker, sync, promote-backlog\nRun 'rihal-tools.cjs help' for the full list of state subcommands.`);
+  // --- render ---
+  // Generate .planning/STATE.md from state.json. Closes #222 — STATE.md is
+  // a rendered view, never the source of truth. Pre-commit hook (#199)
+  // auto-runs this when state.json changes.
+  if (sub === 'render') {
+    const state = readState();
+    if (!state) {
+      throw new Error('state render: no state.json — run a council or plan to initialize state first');
+    }
+    const planningDir = path.join(PROJECT_ROOT, '.planning');
+    fs.mkdirSync(planningDir, { recursive: true });
+    const statePath = path.join(planningDir, 'STATE.md');
+
+    const lines = [];
+    lines.push(`# ${state.project || 'Project'} — State`);
+    lines.push('');
+    lines.push(`**Last rendered:** ${new Date().toISOString().slice(0, 10)}`);
+    lines.push(`**Source of truth:** \`.rihal/state.json\` (this file is auto-generated; do not edit by hand)`);
+    if (state.milestone) lines.push(`**Milestone:** ${state.milestone}`);
+    if (state.current_phase) lines.push(`**Current phase:** ${state.current_phase}`);
+    lines.push('');
+
+    lines.push('---');
+    lines.push('');
+
+    lines.push('## Decisions');
+    lines.push('');
+    const decisions = state.decisions || [];
+    if (decisions.length === 0) {
+      lines.push('_None recorded yet. Use `state add-decision` to capture._');
+    } else {
+      for (const d of decisions) {
+        const date = d.date ? d.date.slice(0, 10) : '';
+        const text = d.summary || d.text || '(no summary)';
+        const meta = [];
+        if (d.workflow) meta.push(`via ${d.workflow}`);
+        if (d.reversibility) meta.push(d.reversibility);
+        const metaStr = meta.length ? ` _(${meta.join(', ')})_` : '';
+        lines.push(`- **${date}** ${text}${metaStr}`);
+      }
+    }
+    lines.push('');
+
+    lines.push('## Blockers');
+    lines.push('');
+    const blockers = (state.blockers || []).filter(b => !b.resolved);
+    if (blockers.length === 0) {
+      lines.push('_None._');
+    } else {
+      for (const b of blockers) {
+        lines.push(`- ⚠ ${b.description || b.text || '(no description)'}`);
+      }
+    }
+    lines.push('');
+
+    if (state.phases && state.phases.length > 0) {
+      lines.push('## Phases');
+      lines.push('');
+      for (const p of state.phases) {
+        const num = p.number || '?';
+        const name = p.name || '(unnamed)';
+        const status = p.status || 'planned';
+        lines.push(`- **[${num}]** ${name} — _${status}_`);
+      }
+      lines.push('');
+    }
+
+    lines.push('---');
+    lines.push('');
+    lines.push('_Re-render: `node .rihal/bin/rihal-tools.cjs state render`_');
+    lines.push('_Add a decision: `node .rihal/bin/rihal-tools.cjs state add-decision "<text>"`_');
+    lines.push('');
+
+    fs.writeFileSync(statePath, lines.join('\n'));
+    return { ok: true, rendered: statePath, decisions: decisions.length, blockers: blockers.length, phases: (state.phases || []).length };
+  }
+
+  // --- set-ids-in-state (deprecated alias for sync --from-disk per #227) ---
+  if (sub === 'set-ids-in-state' && false) { /* placeholder — see deprecation below */ }
+
+  throw new Error(`Unknown state subcommand: ${sub}.\nCommon: read, set-phase, advance-plan, add-decision, decisions-global, add-blocker, sync, render, promote-backlog\nRun 'rihal-tools.cjs help' for the full list of state subcommands.`);
 }
 
 /**

--- a/rihal/commands/checkpoint-preview.md
+++ b/rihal/commands/checkpoint-preview.md
@@ -1,0 +1,19 @@
+---
+name: rihal:checkpoint-preview
+description: LLM-assisted human-in-the-loop review. Make sense of a change, focus attention where it matters, test. Use when the user says checkpoint, human review, or walk me through this change.
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-checkpoint-preview` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-checkpoint-preview/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-checkpoint-preview/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-checkpoint-preview/SKILL.md

--- a/rihal/commands/create-architecture.md
+++ b/rihal/commands/create-architecture.md
@@ -1,0 +1,19 @@
+---
+name: rihal:create-architecture
+description: create-architecture workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-create-architecture` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-create-architecture/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-create-architecture/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-create-architecture/SKILL.md

--- a/rihal/commands/create-milestone.md
+++ b/rihal/commands/create-milestone.md
@@ -1,0 +1,19 @@
+---
+name: rihal:create-milestone
+description: create-milestone workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-create-milestone` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-create-milestone/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-create-milestone/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-create-milestone/SKILL.md

--- a/rihal/commands/create-prd.md
+++ b/rihal/commands/create-prd.md
@@ -1,0 +1,19 @@
+---
+name: rihal:create-prd
+description: create-prd workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-create-prd` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-create-prd/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-create-prd/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-create-prd/SKILL.md

--- a/rihal/commands/create-ux-design.md
+++ b/rihal/commands/create-ux-design.md
@@ -1,0 +1,19 @@
+---
+name: rihal:create-ux-design
+description: create-ux-design workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-create-ux-design` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-create-ux-design/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-create-ux-design/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-create-ux-design/SKILL.md

--- a/rihal/commands/edit-prd.md
+++ b/rihal/commands/edit-prd.md
@@ -1,0 +1,19 @@
+---
+name: rihal:edit-prd
+description: edit-prd workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-edit-prd` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-edit-prd/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-edit-prd/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-edit-prd/SKILL.md

--- a/rihal/commands/frontend-design.md
+++ b/rihal/commands/frontend-design.md
@@ -1,0 +1,19 @@
+---
+name: rihal:frontend-design
+description: frontend-design workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-frontend-design` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-frontend-design/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-frontend-design/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-frontend-design/SKILL.md

--- a/rihal/commands/prfaq.md
+++ b/rihal/commands/prfaq.md
@@ -1,0 +1,19 @@
+---
+name: rihal:prfaq
+description: Working Backwards PRFAQ challenge to forge product concepts. Use when the user requests to create a PRFAQ, work backwards, or run the PRFAQ challenge.
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-prfaq` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-prfaq/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-prfaq/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-prfaq/SKILL.md

--- a/rihal/commands/product-brief.md
+++ b/rihal/commands/product-brief.md
@@ -1,0 +1,19 @@
+---
+name: rihal:product-brief
+description: product-brief workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-product-brief` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-product-brief/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-product-brief/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-product-brief/SKILL.md

--- a/rihal/commands/qa-generate-e2e-tests.md
+++ b/rihal/commands/qa-generate-e2e-tests.md
@@ -1,0 +1,19 @@
+---
+name: rihal:qa-generate-e2e-tests
+description: qa-generate-e2e-tests workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-qa-generate-e2e-tests` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-qa-generate-e2e-tests/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-qa-generate-e2e-tests/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-qa-generate-e2e-tests/SKILL.md

--- a/rihal/commands/retrospective.md
+++ b/rihal/commands/retrospective.md
@@ -1,0 +1,19 @@
+---
+name: rihal:retrospective
+description: retrospective workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-retrospective` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-retrospective/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-retrospective/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-retrospective/SKILL.md

--- a/rihal/commands/validate-prd.md
+++ b/rihal/commands/validate-prd.md
@@ -1,0 +1,19 @@
+---
+name: rihal:validate-prd
+description: validate-prd workflow
+argument-hint: ""
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<delegate_to_skill>
+This slash command delegates to the `rihal-validate-prd` skill.
+Authoritative behaviour lives in:
+  - `.claude/skills/rihal-validate-prd/SKILL.md` (triggers, output format, examples)
+  - `.claude/skills/rihal-validate-prd/workflow.md` (Critical Rules, step files)
+
+Load both before running. The skill's safety rails (halt-at-menu,
+state-sync, no-bypass) MUST fire whether activated by phrase or this
+slash command. Closes #218.
+</delegate_to_skill>
+
+@.claude/skills/rihal-validate-prd/SKILL.md

--- a/rihal/skills/_shared/state-as-ssot-rule.md
+++ b/rihal/skills/_shared/state-as-ssot-rule.md
@@ -1,0 +1,94 @@
+# State as Single Source of Truth
+
+Referenced by every workflow that touches project decisions, blockers,
+phases, sprints, or epics. Closes #222 — the STATE.md vs state.json
+divergence that confused the interpos audit.
+
+## The rule
+
+`.rihal/state.json` is the **only** authoritative source for project
+state. Specifically: decisions, blockers, current_phase, milestone,
+phases[], epics[].stories[], sprints[].
+
+`.planning/STATE.md` (the markdown file) is a **rendered view** of
+state.json — never edit it by hand, never write to it from a workflow.
+
+## Why
+
+Two writers = two sources of truth = inevitable divergence. The
+interpos audit found 7 decisions in STATE.md and 0 in state.json.
+`/rihal:status` (which reads state.json) showed an empty project
+while STATE.md (which a human had written) showed the real picture.
+
+## How to apply
+
+### When recording a decision
+
+❌ DO NOT write decision prose to STATE.md or anywhere else.
+
+✅ DO use the CLI:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision \
+  "Stack locked: NextJS + NestJS + Postgres" \
+  --workflow autonomous \
+  --reversibility one-way
+```
+
+Returns the decision id. The decision now appears in `state.decisions[]`
+and is searchable via `/rihal:why <id>`.
+
+### When updating phase / sprint / epic state
+
+❌ DO NOT hand-edit STATE.md.
+
+✅ DO let workflows write planning artifacts (ROADMAP.md, epics.md,
+sprint-N.md, SUMMARY.md), then run state sync:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+This re-parses disk and upserts into state.json. STATE.md gets
+re-rendered automatically (see below).
+
+### When rendering STATE.md for human consumption
+
+```bash
+node .rihal/bin/rihal-tools.cjs state render
+```
+
+Generates `.planning/STATE.md` from state.json — a markdown view of
+everything in state. Useful for git diffs, PR reviews, and humans
+scanning project state without running CLI.
+
+The pre-commit hook (#199) automatically runs `state render` whenever
+state.json changes, so STATE.md stays current without manual effort.
+
+## Migration for existing projects
+
+If your project's STATE.md has decisions that aren't in state.json yet:
+
+```bash
+# 1. Show the divergence
+diff <(node .rihal/bin/rihal-tools.cjs state read | jq '.decisions[].summary') \
+     <(grep "^- \\*\\*[0-9]" .planning/STATE.md)
+
+# 2. Manually add the missing ones via CLI
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>" --workflow migration
+
+# 3. Render to confirm
+node .rihal/bin/rihal-tools.cjs state render
+diff .planning/STATE.md /dev/stdin <<< "$(node .rihal/bin/rihal-tools.cjs state read)"
+```
+
+## Forbidden patterns
+
+`grep` should return ZERO matches across `rihal/workflows/`:
+
+```bash
+grep -E "Write\\(.*STATE\\.md|append.*STATE\\.md|>>.*STATE\\.md" rihal/workflows/*.md
+```
+
+If anything matches, that workflow is breaking the rule and must be
+converted to use `state add-decision` + `state render`.

--- a/rihal/workflows/check-implementation-readiness.md
+++ b/rihal/workflows/check-implementation-readiness.md
@@ -4,6 +4,31 @@
 Pre-execution gate: verify PRD approved, architecture approved, external dependencies identified, and no blocking assumptions remain. Return pass/fail report. Used as guard in plan.md Step 0.8 and execute.md Step 0.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-check-implementation-readiness` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-check-implementation-readiness/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-check-implementation-readiness/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-check-implementation-readiness not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 
 ## Step 0 — Usage check
 

--- a/rihal/workflows/correct-course.md
+++ b/rihal/workflows/correct-course.md
@@ -4,6 +4,31 @@
 Load original PRD and architecture docs, compare against current codebase implementation. Identify deviations, classify by type (scope drift, wrong architecture, missing acceptance criteria, tech debt), and produce ordered remediation plan with updated story file.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-correct-course` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-correct-course/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-correct-course/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-correct-course not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 
 ## Step 0 — Usage check
 

--- a/rihal/workflows/create-epics-and-stories.md
+++ b/rihal/workflows/create-epics-and-stories.md
@@ -4,6 +4,31 @@
 Parse a PRD, PROJECT.md, or project document to generate numbered epic files in `.planning/epics/`. Each epic file contains user stories with acceptance criteria, development notes, and effort estimates. Output is ready for `/rihal:sprint-planning`.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-create-epics-and-stories` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-create-epics-and-stories/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-create-epics-and-stories/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-create-epics-and-stories not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 
 <available_agent_types>
 - `rihal-roadmapper` — reads PRD/context and generates epic structure

--- a/rihal/workflows/create-story.md
+++ b/rihal/workflows/create-story.md
@@ -4,6 +4,31 @@
 Convert a single story from an EPIC file into a self-contained STORY.md file. This story is ready for `/rihal:dev-story` to be wrapped for AI-coder execution. Entry is gated by checklist-story-draft.md.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-create-story` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-create-story/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-create-story/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-create-story not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 
 ## Step 0 — Usage check
 

--- a/rihal/workflows/dev-story.md
+++ b/rihal/workflows/dev-story.md
@@ -11,6 +11,31 @@ Wrap a STORY.md file for AI-coder consumption. Produces:
 This workflow creates the execution prompt for a pair-programming session with an AI coder.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-dev-story` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-dev-story/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-dev-story/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-dev-story not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 
 ## Step 0 — Parse Arguments
 

--- a/rihal/workflows/do.md
+++ b/rihal/workflows/do.md
@@ -2,6 +2,35 @@
 Analyze freeform text from the user and route to the most appropriate Rihal command. This is a dispatcher — it never does the work itself. Match user intent to the best command, confirm the routing, and hand off.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 <required_reading>
 @.rihal/references/output-format.md
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/rihal/workflows/document-project.md
+++ b/rihal/workflows/document-project.md
@@ -4,6 +4,31 @@
 Load documentation-requirements.csv, audit current documentation for coverage and staleness, identify missing or outdated docs, and file them as SPRINT.md subtasks or separate plan phases.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-document-project` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-document-project/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-document-project/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-document-project not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 
 ## Step 0 — Usage check
 

--- a/rihal/workflows/execute-sprint.md
+++ b/rihal/workflows/execute-sprint.md
@@ -2,6 +2,35 @@
 Execute a phase prompt (SPRINT.md) and create the outcome summary (SUMMARY.md).
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 <required_reading>
 Read STATE.md before any operation to load project context.
 Read config.json for planning behavior settings.

--- a/rihal/workflows/execute.md
+++ b/rihal/workflows/execute.md
@@ -2,6 +2,73 @@
 Execute all plans in a phase using wave-based parallel execution. Orchestrator stays lean — delegates plan execution to subagents.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
+<prerequisite_check priority="absolute">
+
+## 0. Prerequisite check (closes #225)
+
+Before executing ANY phase, verify the upstream chain has produced what
+this workflow assumes exists. Skip = inverted methodology = low-quality
+output (the interpos pattern from #219).
+
+```bash
+PHASE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+(.[0-9]+)?' | head -1)
+PHASE_DIR=$(ls -d .planning/phases/${PHASE_NUM}-* 2>/dev/null | head -1)
+HAS_PRD=$([ -f .planning/prd.md ] && echo true || echo false)
+HAS_PLAN=$([ -n "$PHASE_DIR" ] && ls "$PHASE_DIR"/*-PLAN.md "$PHASE_DIR"/PLAN.md 2>/dev/null | head -1 | grep -q . && echo true || echo false)
+HAS_SPRINT=$([ -n "$PHASE_DIR" ] && ls "$PHASE_DIR"/*-SPRINT.md "$PHASE_DIR"/SPRINT.md 2>/dev/null | head -1 | grep -q . && echo true || echo false)
+SKIP_FLAG=$(echo "$ARGUMENTS" | grep -qE "--skip-prerequisites" && echo true || echo false)
+```
+
+If `SKIP_FLAG=false` AND any prerequisite is missing, HALT with:
+
+```
+⚠ Cannot execute phase ${PHASE_NUM}: missing {what}.
+
+The /rihal:execute workflow assumes:
+  • .planning/prd.md exists           (PRD foundation)
+  • PLAN.md exists for the target phase (run /rihal:plan ${PHASE_NUM} first)
+  • SPRINT.md exists                  (run /rihal:sprint-planning --phase ${PHASE_NUM} first)
+
+Suggested next step: /rihal:{first-missing-command}
+
+Override with: /rihal:execute --skip-prerequisites
+(rare — only when you genuinely want to bypass the methodology gate)
+```
+
+Do not proceed past this step until either every prerequisite is satisfied
+OR `--skip-prerequisites` is set.
+
+</prerequisite_check>
+
 <pre_flight>
 **Mandatory before execution begins.** Run these checks first and surface
 findings BEFORE any subagents are spawned. If any check fails, stop and

--- a/rihal/workflows/forensics.md
+++ b/rihal/workflows/forensics.md
@@ -4,6 +4,35 @@
 Analyze execution history in state.json and filesystem to detect incomplete work. Show timeline of what happened, where it broke, and suggest resume command.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 
 ## Step 0 — Usage check
 

--- a/rihal/workflows/help.md
+++ b/rihal/workflows/help.md
@@ -2,6 +2,35 @@
 Display the Rihal command reference at the requested tier. Output ONLY the tier section. Do NOT add project-specific analysis, git status, next-step suggestions, or any commentary beyond the reference.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 ## Step 0 — Parse arguments
 
 Read `$ARGUMENTS` and resolve to one of: `basic`, `intermediate`, `advanced`, `all`.

--- a/rihal/workflows/new-project-research.md
+++ b/rihal/workflows/new-project-research.md
@@ -6,6 +6,35 @@ Research phase of /rihal:new-project. Loaded from new-project.md via @-reference
 **Invariants from parent:** {project_name}, {planning_artifacts}, {researcher_model}, {synthesizer_model}, {user_preference_research}. Set in new-project.md Steps 1–5.5 before this loads.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 ## 6. Research Decision
 
 **If auto mode:** Default to "Research first" without asking.

--- a/rihal/workflows/new-project.md
+++ b/rihal/workflows/new-project.md
@@ -3,8 +3,48 @@ Initialize a new project through unified flow: questioning, research (optional),
 
 </purpose>
 
+<chain_orchestration priority="absolute">
+
+## 0. Methodology chain orchestration (closes #226)
+
+`/rihal:new-project` is the ONLY workflow that creates the upstream chain
+out of nothing. It MUST trigger the create-prd → create-milestone →
+create-epics-and-stories chain in order, not skip to phase scaffolding.
+
+Required call sequence (each step halts for user review before next):
+
+```
+1. /rihal:create-prd               → produces .planning/prd.md
+   (skip if --prd <path> flag points to existing PRD; load that instead)
+
+2. /rihal:create-milestone         → produces .planning/ROADMAP.md with M1..Mn
+   (input: prd.md from step 1)
+
+3. /rihal:create-epics-and-stories → produces .planning/epics.md
+   (input: M1 from step 2)
+
+4. /rihal:sprint-planning --phase 01 → produces first sprint
+   (input: epics.md from step 3)
+
+5. State sync at every step:
+   node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+If `--auto` flag is set, halts are minimized but each chain step still
+runs in order. If `--skip-prerequisites` is set, this orchestration is
+bypassed (rare — usually means user has another tool generating these
+artifacts).
+
+NEVER hand-write PROJECT.md, ROADMAP.md, or epics.md inline — always
+delegate to the upstream skills so their safety rails (citation rule,
+capacity gate, halt-at-menu) fire. See `_shared/no-autonomous-bypass.md`.
+
+</chain_orchestration>
+
 <required_reading>
 @.rihal/references/output-format.md
+@.rihal/skills/_shared/no-autonomous-bypass.md
+@.rihal/skills/_shared/state-sync-rule.md
 
 Read all files referenced by the invoking prompt's execution_context before starting.
 </required_reading>

--- a/rihal/workflows/plan.md
+++ b/rihal/workflows/plan.md
@@ -2,6 +2,35 @@
 Create executable phase prompts (SPRINT.md files) for a roadmap phase with integrated research and verification. Default flow: Research (if needed) -> Plan -> Verify -> Done. Orchestrates rihal-phase-researcher, rihal-planner, and rihal-sprint-checker agents with a revision loop (max 3 iterations).
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 <output_format>
 Open with banner:
 

--- a/rihal/workflows/quick.md
+++ b/rihal/workflows/quick.md
@@ -8,6 +8,35 @@ variable, commit uncommitted work, add a .gitignore entry, bump a version number
 Use /rihal:quick for anything that needs multi-step planning or research.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 <process>
 
 <step name="parse_task">

--- a/rihal/workflows/ship.md
+++ b/rihal/workflows/ship.md
@@ -2,6 +2,35 @@
 Create a pull request from completed phase/milestone work, generate a rich PR body from planning artifacts, optionally run code review, and prepare for merge. Closes the plan → execute → verify → ship loop.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.
 </required_reading>

--- a/rihal/workflows/sprint-status.md
+++ b/rihal/workflows/sprint-status.md
@@ -4,6 +4,31 @@
 Display current sprint progress: stories by status, points done vs remaining, velocity comparison, and burndown. Quick situational awareness without starting execution.
 </purpose>
 
+<delegate_to_skill>
+**Authoritative implementation lives in the `rihal-sprint-status` skill.**
+This workflow exists for slash-command activation. To preserve every
+safety rail (halt-at-menu, capacity gates, citation rules, state-sync
+rules), load and follow the skill's files BEFORE running any in-line
+steps below:
+
+- `.claude/skills/rihal-sprint-status/SKILL.md` — triggers + Output Format + Examples
+- `.claude/skills/rihal-sprint-status/workflow.md` — Critical Rules + step files
+
+Apply every rule from the skill's `## CRITICAL RULES (NO EXCEPTIONS)` block.
+The in-line steps in this file are a legacy fallback only — they are
+NOT the authoritative behaviour.
+
+After this workflow writes any `.planning/` artifact, ALWAYS run:
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+Per `_shared/state-sync-rule.md` (#198).
+
+If the skill is not installed: print
+"Skill rihal-sprint-status not found. Run: npx @hanzlaa/rcode install"
+and exit non-zero. Do not proceed with the legacy in-line steps.
+</delegate_to_skill>
+
 <output_format>
 Open with banner:
 ```

--- a/rihal/workflows/verify-work.md
+++ b/rihal/workflows/verify-work.md
@@ -4,6 +4,35 @@ Validate built features through conversational testing with persistent state. Cr
 User tests, Claude records. One test at a time. Plain text responses.
 </purpose>
 
+<state_sync_rule priority="enforce">
+
+## State sync (NO EXCEPTIONS)
+
+After this workflow writes any `.planning/` artifact (ROADMAP.md, prd.md,
+epics.md, PLAN.md, SPRINT.md, SUMMARY.md, etc.) OR records a decision,
+ALWAYS run:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state sync --from-disk
+```
+
+Skipping this drifts state.json from disk. `/rihal:status`, `/rihal:progress`,
+and `/rihal:execute` all read state.json and lie when it's stale.
+Closes #198 / #223 across the workflow surface.
+
+For decision capture, use the CLI — never write decision prose into
+STATE.md directly:
+
+```bash
+node .rihal/bin/rihal-tools.cjs state add-decision "<text>"   --workflow <workflow-name>   --reversibility one-way|reversible|nuanced
+```
+
+This populates `state.decisions[]` so `/rihal:why <decision-id>` and
+`~/.rihal/decisions.jsonl` stay accurate. Closes #224 across the
+workflow surface.
+
+</state_sync_rule>
+
 <output_format>
 Open with banner:
 ```


### PR DESCRIPTION
Continues v2.4 from PR #230. Closes 7 of 8 remaining tickets, big chunk of #228.

## Closes

- #218 (remainder — 7 workflow→skill delegations + 12 command-alias files)
- #222 STATE.md as rendered view (state.json SSOT) + new \`state render\` CLI
- #223 state-sync sweep (10 more workflows now reference the rule)
- #224 decisions via \`state add-decision\` CLI (not STATE.md prose)
- #225 /rihal:execute prerequisite check
- #226 /rihal:new-project chain orchestration
- #227 \`set-ids-in-state\` deprecation warning

## Substantial progress on

- #228 — 12 of 45 dangling slash-command refs now resolved by creating command-file aliases for action skills that existed but had no slash command. Remaining ~33 are aliases + false positives, address in follow-up.

## Files changed

| Area | Files | What |
|------|-------|------|
| Workflow delegate blocks | 7 workflow.md | Slash commands now route through skills |
| Workflow state-sync rule | 10 workflow.md | Auto-sync after .planning/ writes |
| Workflow prereq checks | 2 (execute, new-project) | Halt on missing upstream artifacts |
| Workflow alias commands | 12 new in rihal/commands/ | Skill-level commands now slash-accessible |
| Shared rule | 1 new (state-as-ssot-rule.md) | Documents STATE.md vs state.json |
| CLI | rihal-tools.cjs | New \`state render\` subcommand + deprecation warning |

33 files changed, 970 insertions, 67 deletions.

## Verification

- \`grep -l delegate_to_skill rihal/workflows/*.md\` → 8 (sprint-planning from #230 + 7 new)
- \`grep -l state_sync_rule rihal/workflows/*.md\` → 10
- \`grep -l prerequisite_check rihal/workflows/*.md\` → 2 (execute, autonomous from #230)
- \`grep -l chain_orchestration rihal/workflows/*.md\` → 1 (new-project)
- \`ls rihal/commands/ | wc -l\` → +12 new
- \`node rihal/bin/rihal-tools.cjs state render\` → produces clean STATE.md
- \`node rihal/bin/rihal-tools.cjs state set-ids-in-state\` → emits deprecation stderr

## Architecture impact

Combined with PR #230 (already merged), the v2.4 milestone now ensures:
1. Slash commands cannot bypass skill safety rails
2. /rihal:do refuses to invert the methodology chain
3. /rihal:autonomous halts if PRD/milestone/epics missing
4. /rihal:autonomous never silently flips mode
5. /rihal:execute halts if PLAN.md/SPRINT.md missing
6. /rihal:new-project orchestrates the create-prd → milestone → epics → sprint chain
7. Decisions flow through state.json (one source of truth, rendered to STATE.md)
8. 12 action skills are now slash-accessible (create-prd, create-milestone, prfaq, etc.)

The interpos failure mode is now blocked at multiple layers.

## Remaining v2.4 work

- #228 follow-up — audit + fix the ~33 remaining dangling refs (mix of aliases + false positives)