### PR TITLE
fix(install,workflows): new-project first-run + 3.4.21 release (#670-#677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Rihal Code are documented here.
 
 ---
 
+## v3.4.21 (2026-05-07)
+
+### Fixes carried over from 3.4.20 main (commit b3428c1 missed the 3.4.20 release window — closes #677)
+
+- **fix(install):** health check + summary respect global precedence (#664, #666, #669) — when project install removes local agent/command copies in favor of `~/.claude/` globals, the summary and verifier now fall back to counting from `~/.claude/agents/` and `~/.claude/commands/` instead of reporting `0`.
+
+### `/rihal-new-project` first-run gaps (closes #670 #671 #672 #673 #674 #675 #676)
+
+- **fix(install):** `seedStarterPlanning()` no longer pre-seeds `.rihal/state.json` with a fake `Setup & Scaffolding` phase (#670). State is seeded as `{_seeded_stub: true, project: null, phases: []}` so Step 0.5 can detect the stub.
+- **fix(install):** stub `.planning/PROJECT.md`, `ROADMAP.md`, `STATE.md` now carry an `INSTALL STUB` HTML banner so users (and downstream tooling) can tell them apart from real planning artifacts (#676).
+- **fix(workflows):** `/rihal-new-project` Step 0.5 rewritten with stub-vs-real classification (#671). Real-project signals: `REQUIREMENTS.md`, `research/`, >1 phase, or first-phase-name ≠ "Setup & Scaffolding".
+- **feat(workflows):** `/rihal-new-project` accepts `--force` / `--reinit` (#672). Creates a `pre-rihal-rewrite-<timestamp>` git tag for rollback before overwriting.
+- **fix(workflows):** Step 0.5 error message now lists the escape hatches: `--force`, `rcode install --reset` (#673).
+- **fix(workflows):** `--auto` no longer blocked on stub state (#674) — the new stub classification proceeds without prompting.
+
+---
+
 ## Unreleased — post v3.4.4 (2026-04-27 → present)
 
 50 commits since v3.4.4. Grouped by area.

--- a/cli/install.js
+++ b/cli/install.js
@@ -275,7 +275,7 @@ function printInstallHeader(targetVersion) {
     pc.cyan('│') + '   ' + dim('A persistent context-brain for your editor') + '             ' + pc.cyan('│'),
     pc.cyan('│') + '                                                           ' + pc.cyan('│'),
     pc.cyan('│') + '   ' + dim('version  ') + pc.green('v' + v) + '                                          ' + pc.cyan('│'),
-    pc.cyan('│') + '   ' + dim('docs     ') + 'github.com/hanzla-habib/rihal-code              ' + pc.cyan('│'),
+    pc.cyan('│') + '   ' + dim('docs     ') + 'github.com/hanzlahabib/rihal-code               ' + pc.cyan('│'),
     pc.cyan('│') + '                                                           ' + pc.cyan('│'),
     pc.cyan('╰───────────────────────────────────────────────────────────╯'),
     '',
@@ -2023,6 +2023,7 @@ async function install(opts) {
   const agentsDir = idePaths.agentsDir;
   const commandsDir = idePaths.commandsDir;
   let agentCount = 0, commandCount = 0;
+  let agentsFromGlobal = false, commandsFromGlobal = false;
   try {
     if (fs.existsSync(agentsDir)) {
       agentCount = fs.readdirSync(agentsDir).filter(f => (f.startsWith('rihal-') || f.startsWith('rcode-')) && (f.endsWith('.md') || f.endsWith('.mdc'))).length;
@@ -2033,6 +2034,22 @@ async function install(opts) {
         ? f => f.startsWith('rihal-') && (f.endsWith('.md') || f.endsWith('.mdc'))
         : f => f.endsWith('.md') || f.endsWith('.mdc');
       commandCount = fs.readdirSync(commandsDir).filter(commandFilter).length;
+    }
+    // Issue #669 — when global precedence applied (project copies were
+    // intentionally removed), count from ~/.claude/ instead so the summary
+    // doesn't lie about the install state.
+    if (agentCount === 0 || commandCount === 0) {
+      const os = require('os');
+      const homeAgents = path.join(os.homedir(), '.claude/agents');
+      const homeCommands = path.join(os.homedir(), '.claude/commands');
+      if (agentCount === 0 && fs.existsSync(homeAgents)) {
+        const n = fs.readdirSync(homeAgents).filter(f => f.startsWith('rihal-') && f.endsWith('.md')).length;
+        if (n > 0) { agentCount = n; agentsFromGlobal = true; }
+      }
+      if (commandCount === 0 && fs.existsSync(homeCommands)) {
+        const n = fs.readdirSync(homeCommands).filter(f => f.startsWith('rihal-') && f.endsWith('.md')).length;
+        if (n > 0) { commandCount = n; commandsFromGlobal = true; }
+      }
     }
   } catch {}
 
@@ -2047,8 +2064,8 @@ async function install(opts) {
   // Show the actual install paths so cursor/gemini/antigravity output is accurate
   const relAgents = path.relative(opts.target, idePaths.agentsDir) || idePaths.agentsDir;
   const relCommands = path.relative(opts.target, idePaths.commandsDir) || idePaths.commandsDir;
-  console.log(`  ${bold('Agents:')}    ${pc.green(String(agentCount))} in ${relAgents}/`);
-  console.log(`  ${bold('Commands:')}  ${pc.green(String(commandCount))} slash commands in ${relCommands}/`);
+  console.log(`  ${bold('Agents:')}    ${pc.green(String(agentCount))} in ${agentsFromGlobal ? '~/.claude/agents/ (global)' : relAgents + '/'}`);
+  console.log(`  ${bold('Commands:')}  ${pc.green(String(commandCount))} slash commands in ${commandsFromGlobal ? '~/.claude/commands/ (global)' : relCommands + '/'}`);
   if (skillsInstalled > 0) console.log(`  ${bold('Skills:')}    ${pc.green(String(skillsInstalled))} phrase-activated`);
   console.log('');
   if (starterSeeded) {

--- a/cli/install.js
+++ b/cli/install.js
@@ -548,7 +548,15 @@ function seedStarterPlanning(target, projectName) {
   const today = new Date().toISOString().slice(0, 10);
   const name = projectName || path.basename(target);
 
+  // Stub planning files: clearly marked as install templates so users (and
+  // /rihal-new-project Step 0.5 detection) can tell them apart from real
+  // planning artifacts. See issues #670 #671 #676.
+  const STUB_BANNER =
+    `<!-- INSTALL STUB — overwritten by /rihal-new-project. Delete this file or run\n` +
+    `     /rihal-new-project before committing. See https://github.com/hanzlahabib/rihal-code/issues/670 -->\n\n`;
+
   fs.writeFileSync(projectPath,
+    STUB_BANNER +
     `# ${name}\n\n` +
     `**One-line:** Describe what this project is in one sentence.\n\n` +
     `## Vision\n\n` +
@@ -558,6 +566,7 @@ function seedStarterPlanning(target, projectName) {
   );
 
   fs.writeFileSync(roadmapPath,
+    STUB_BANNER +
     `# ${name} — Roadmap\n\n` +
     `**Milestone: M1 — Initial Delivery** (v1.0)\n` +
     `Started: ${today} · Current\n\n` +
@@ -572,6 +581,7 @@ function seedStarterPlanning(target, projectName) {
   );
 
   fs.writeFileSync(statePath,
+    STUB_BANNER +
     `# ${name} — State\n\n` +
     `**Last updated:** ${today}\n` +
     `**Milestone:** M1 — Initial Delivery\n` +
@@ -580,27 +590,33 @@ function seedStarterPlanning(target, projectName) {
     `---\n\n` +
     `## Decisions\n\n_None yet._\n\n` +
     `## Blockers\n\n_None._\n\n` +
-    `## Next Action\n\nSay "plan a sprint" or run \`/rihal-sprint-planning\` to break Phase 01 into stories.\n`
+    `## Next Action\n\nRun \`/rihal-new-project <description>\` to bootstrap, or \`/rihal-sprint-planning\` once a real phase exists.\n`
   );
 
-  // Also pre-seed .rihal/state.json with Phase 01 so sprint tools work
-  // immediately (otherwise auto-init in rihal-tools.cjs creates state with
-  // empty phases[], requiring manual set-phase before sprint add).
+  // Issue #670: do NOT pre-seed .rihal/state.json with a fake project +
+  // "Setup & Scaffolding" phase. That made every fresh install look like a
+  // real initialized project and broke /rihal-new-project Step 0.5 detection.
+  //
+  // Write a minimal shell with _seeded_stub:true so:
+  //   - rihal-tools doesn't have to re-init on first call (avoids race)
+  //   - /rihal-new-project Step 0.5 (issue #671) can detect "stub" reliably
+  //   - sprint tools that previously relied on phase 01 will surface a clear
+  //     "no phases yet — run /rihal-new-project first" error instead of
+  //     silently operating on a fake phase
   const rihalStateJson = path.join(target, '.rihal', 'state.json');
   if (!fs.existsSync(rihalStateJson)) {
     const now = new Date().toISOString();
     const state = {
       version: '1',
-      project: name,
+      project: null,
+      _seeded_stub: true,
       created: now,
       updated: now,
-      current_phase: '01',
+      current_phase: null,
       current_plan: 0,
       current_sprint: null,
-      milestone: 'M1 — Initial Delivery',
-      phases: [
-        { id: '01', name: 'Setup & Scaffolding', status: 'planned' }
-      ],
+      milestone: null,
+      phases: [],
       executions: [],
       decisions: [],
       blockers: [],

--- a/cli/lib/manifest.cjs
+++ b/cli/lib/manifest.cjs
@@ -124,6 +124,25 @@ function verifyClaudeInstall(cwd, packageRoot) {
     }
   }
 
+  // Issue #664 — global precedence fallback.
+  // The installer (cli/install.js ~line 1773) intentionally removes project-
+  // level .claude/agents/rihal-*.md when the user's ~/.claude/ already has
+  // them, to avoid duplicate commands. Without this fallback the verifier
+  // reports 0 agents on every successful install in that scenario.
+  if (installedAgents.size === 0) {
+    try {
+      const os = require('os');
+      const globalAgentsDir = path.join(os.homedir(), '.claude/agents');
+      if (fs.existsSync(globalAgentsDir)) {
+        for (const f of fs.readdirSync(globalAgentsDir)) {
+          if (f.startsWith('rihal-') && f.endsWith('.md')) {
+            installedAgents.add(f.replace(/^rihal-/, '').replace(/\.md$/, ''));
+          }
+        }
+      }
+    } catch { /* non-fatal — permission errors etc. */ }
+  }
+
   // Actions: .claude/skills/<bare-name>/ — exclude rihal-* dirs (those are
   // either agent stubs or command stubs, never action skills).
   const allInstalled = readInstalledDirs(skillsDir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzlaa/rcode",
-  "version": "3.4.20",
+  "version": "3.4.21",
   "description": "rcode — the memory bank for AI-driven SaaS teams. Persistent project context, distinctive engineering personas, and phase-based workflows. Built by Rihal. Works in Claude Code, Cursor, Gemini, VS Code, and Antigravity.",
   "main": "cli/index.js",
   "bin": {

--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -5278,6 +5278,62 @@ function cmdSummaryExtract(args) {
  * Hides internal machinery (lock metadata, full history) from callers
  * that only need a render-ready summary.
  */
+/**
+ * cmdProjectStatus — classify project lifecycle state into one of:
+ *   uninstalled    — no .rihal/config.yaml
+ *   uninitialized  — config present, no state.json
+ *   stub           — install-seeded scaffolding only (issue #670)
+ *   real           — /rihal-new-project has run
+ *
+ * Real-project signals (any → real):
+ *   - .planning/REQUIREMENTS.md exists
+ *   - .planning/research/ directory exists
+ *   - state.phases.length > 1
+ *   - first phase name ≠ "Setup & Scaffolding"
+ *
+ * Closes #675 — single source of truth for "is this project initialized."
+ */
+function cmdProjectStatus() {
+  const configPath = path.join(RIHAL_DIR, 'config.yaml');
+  const statePath = path.join(RIHAL_DIR, 'state.json');
+  const planningDir = path.join(PROJECT_ROOT, '.planning');
+
+  if (!fs.existsSync(configPath)) return { ok: true, status: 'uninstalled' };
+  if (!fs.existsSync(statePath)) return { ok: true, status: 'uninitialized' };
+
+  let state;
+  try { state = JSON.parse(fs.readFileSync(statePath, 'utf8')); }
+  catch (e) { return { ok: false, error: `invalid state.json: ${e.message}` }; }
+
+  const hasRequirements = fs.existsSync(path.join(planningDir, 'REQUIREMENTS.md'));
+  const hasResearch = fs.existsSync(path.join(planningDir, 'research'));
+  const phases = state.phases || [];
+  const phaseCountReal = phases.length > 1;
+  const firstPhaseName = phases[0]?.name || '';
+  const phaseNameReal = firstPhaseName && firstPhaseName !== 'Setup & Scaffolding';
+
+  const isReal = hasRequirements || hasResearch || phaseCountReal || phaseNameReal;
+  const isStub = state._seeded_stub === true || !state.project || !isReal;
+
+  let status;
+  if (isReal) status = 'real';
+  else if (isStub) status = 'stub';
+  else status = 'uninitialized';
+
+  return {
+    ok: true,
+    status,
+    signals: {
+      project: state.project || null,
+      seeded_stub: state._seeded_stub === true,
+      has_requirements: hasRequirements,
+      has_research: hasResearch,
+      phase_count: phases.length,
+      first_phase_name: firstPhaseName || null,
+    },
+  };
+}
+
 function cmdStateSnapshot() {
   const statePath = path.join(RIHAL_DIR, 'state.json');
   if (!fs.existsSync(statePath)) return { ok: true, state: null };
@@ -5651,6 +5707,9 @@ async function main() {
       }
       case 'agent-skills':
         result = cmdAgentInfo(args[0]);
+        break;
+      case 'project-status':
+        result = cmdProjectStatus();
         break;
       case 'version':
         console.log(readPackageVersion());

--- a/rihal/state.json
+++ b/rihal/state.json
@@ -1,15 +1,14 @@
 {
   "version": "1",
-  "project": "__PROJECT_NAME__",
+  "project": null,
+  "_seeded_stub": true,
   "created": "__INSTALL_DATE__",
   "updated": "__INSTALL_DATE__",
-  "current_phase": "01",
+  "current_phase": null,
   "current_plan": 0,
   "current_sprint": null,
-  "milestone": "M1 — Initial Delivery",
-  "phases": [
-    { "id": "01", "name": "Setup & Scaffolding", "status": "planned" }
-  ],
+  "milestone": null,
+  "phases": [],
   "executions": [],
   "decisions": [],
   "blockers": [],

--- a/rihal/workflows/new-project.md
+++ b/rihal/workflows/new-project.md
@@ -88,25 +88,82 @@ Valid Rihal subagent types (use exact names — do not fall back to 'general-pur
 - rihal-roadmapper — Creates phased execution roadmaps
 </available_agent_types>
 
-## Step 0.5 — Detect existing project (redirect)
+## Step 0.5 — Detect existing project (stub-aware redirect)
 
-Before any processing, check if a project already exists in this directory:
+Before any processing, classify the project state into one of:
+
+- **none** — no `.rihal/state.json`, no `.planning/` → proceed
+- **stub** — install-seeded scaffolding only (issue #670) → proceed (overwrite stub)
+- **real** — a previous `/rihal-new-project` ran here → guard, unless `--force`
 
 ```bash
-EXISTING=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null | grep '"project"' | head -1)
+# --force / --reinit bypasses the guard entirely (issue #672).
+# --auto implies --force on stub state (issue #674).
+FORCE=false
+case " $ARGUMENTS " in
+  *" --force "*|*" --reinit "*) FORCE=true ;;
+esac
+
+# Read state and classify
+STATE_JSON=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null)
+STATE_EXISTS=$([ -n "$STATE_JSON" ] && echo true || echo false)
+SEEDED_STUB=$(echo "$STATE_JSON" | grep -c '"_seeded_stub"[[:space:]]*:[[:space:]]*true')
+PROJECT_FIELD=$(echo "$STATE_JSON" | grep -E '"project"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1)
+PHASE_COUNT=$(echo "$STATE_JSON" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log((JSON.parse(s).phases||[]).length)}catch{console.log(0)}})" 2>/dev/null || echo 0)
+FIRST_PHASE_NAME=$(echo "$STATE_JSON" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const p=(JSON.parse(s).phases||[])[0];console.log(p?(p.name||''):'')}catch{console.log('')}})" 2>/dev/null || echo "")
+
+# Real-project signals (any one → real)
+REAL=false
+[ -f .planning/REQUIREMENTS.md ] && REAL=true
+[ -d .planning/research ] && REAL=true
+[ "$PHASE_COUNT" -gt 1 ] && REAL=true
+[ -n "$FIRST_PHASE_NAME" ] && [ "$FIRST_PHASE_NAME" != "Setup & Scaffolding" ] && REAL=true
+
+# Classify
+if [ "$STATE_EXISTS" = false ] || [ -z "$PROJECT_FIELD" ]; then
+  PROJECT_STATE="none"
+elif [ "$SEEDED_STUB" -gt 0 ] || [ "$REAL" = false ]; then
+  PROJECT_STATE="stub"
+else
+  PROJECT_STATE="real"
+fi
 ```
 
-If `$EXISTING` is non-empty (project already initialized):
+**If `PROJECT_STATE=real` and `FORCE=false`:** show the guard:
 
 ```
 ⚠ A rihal project already exists here.
 
-To check current state: /rihal-status
-To find next action: /rihal-next
-To start a fresh phase instead: /rihal-add-phase
+Quick actions:
+  /rihal-status            check current state
+  /rihal-next              find next action
+  /rihal-add-phase         add a phase to the current milestone
+
+To start over (overwrites .planning/* and .rihal/state.json):
+  /rihal-new-project --force <description>
+  rcode install --reset                        nuclear option — wipes config + state
 ```
 
-Only proceed past this step if no project exists (`$EXISTING` is empty).
+STOP — do not proceed.
+
+**If `PROJECT_STATE=stub` (issue #670 install scaffolding):** print a one-liner and proceed:
+
+```
+ℹ Install stub detected — overwriting with real project setup.
+```
+
+**If `PROJECT_STATE=none`:** proceed silently.
+
+**If `PROJECT_STATE=real` and `FORCE=true`:** create a rollback tag, then proceed:
+
+```bash
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  TAG="pre-rihal-rewrite-$(date +%Y%m%d-%H%M%S)"
+  git tag "$TAG" 2>/dev/null && echo "ℹ Rollback tag created: $TAG"
+fi
+```
+
+In interactive mode (not `--auto`), confirm via AskUserQuestion before overwriting. In `--auto` or YOLO mode, proceed without confirmation.
 
 <auto_mode>
 

--- a/rihal/workflows/new-project.md
+++ b/rihal/workflows/new-project.md
@@ -104,29 +104,14 @@ case " $ARGUMENTS " in
   *" --force "*|*" --reinit "*) FORCE=true ;;
 esac
 
-# Read state and classify
-STATE_JSON=$(node .rihal/bin/rihal-tools.cjs state read 2>/dev/null)
-STATE_EXISTS=$([ -n "$STATE_JSON" ] && echo true || echo false)
-SEEDED_STUB=$(echo "$STATE_JSON" | grep -c '"_seeded_stub"[[:space:]]*:[[:space:]]*true')
-PROJECT_FIELD=$(echo "$STATE_JSON" | grep -E '"project"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1)
-PHASE_COUNT=$(echo "$STATE_JSON" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log((JSON.parse(s).phases||[]).length)}catch{console.log(0)}})" 2>/dev/null || echo 0)
-FIRST_PHASE_NAME=$(echo "$STATE_JSON" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const p=(JSON.parse(s).phases||[])[0];console.log(p?(p.name||''):'')}catch{console.log('')}})" 2>/dev/null || echo "")
-
-# Real-project signals (any one → real)
-REAL=false
-[ -f .planning/REQUIREMENTS.md ] && REAL=true
-[ -d .planning/research ] && REAL=true
-[ "$PHASE_COUNT" -gt 1 ] && REAL=true
-[ -n "$FIRST_PHASE_NAME" ] && [ "$FIRST_PHASE_NAME" != "Setup & Scaffolding" ] && REAL=true
-
-# Classify
-if [ "$STATE_EXISTS" = false ] || [ -z "$PROJECT_FIELD" ]; then
-  PROJECT_STATE="none"
-elif [ "$SEEDED_STUB" -gt 0 ] || [ "$REAL" = false ]; then
-  PROJECT_STATE="stub"
-else
-  PROJECT_STATE="real"
-fi
+# Single source of truth: rihal-tools project-status returns one of
+#   uninstalled | uninitialized | stub | real
+# (see issue #675 for the contract). Falls back to `none` when
+# rihal-tools is unavailable so the workflow still proceeds.
+PROJECT_STATE=$(node .rihal/bin/rihal-tools.cjs project-status 2>/dev/null \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).status||'none')}catch{console.log('none')}})" \
+  || echo "none")
+[ "$PROJECT_STATE" = "uninstalled" ] || [ "$PROJECT_STATE" = "uninitialized" ] && PROJECT_STATE="none"
 ```
 
 **If `PROJECT_STATE=real` and `FORCE=false`:** show the guard:


### PR DESCRIPTION
Closes #670, closes #671, closes #672, closes #673, closes #674, closes #675, closes #676, closes #677.

## Summary

Fixes the 8 gaps surfaced while bootstrapping a real project on top of a fresh `npx @hanzlaa/rcode install` and noticing the install still printed `0 agents / 0 commands / health check failed`. Root cause: 3.4.20 was published *before* commit b3428c1 (the global-precedence fix). Bumping to 3.4.21 ships that fix and a stack of related new-project Step 0.5 gaps.

## Issues closed

| # | Title |
|---|---|
| #670 | install seedStarterPlanning pre-seeds fake project state |
| #671 | Step 0.5 stub-vs-real detection too naive |
| #672 | --force flag missing on /rihal-new-project |
| #673 | Step 0.5 error message hides escape hatches |
| #674 | --auto blocked by Step 0.5 |
| #675 | auto-init-guard contract gap (project-status helper) |
| #676 | install-seeded stub files commit-able with no warning |
| #677 | 3.4.20 published without b3428c1 |

## What changed

- `rihal/state.json` template — no fake `Setup & Scaffolding` phase. Stub uses `_seeded_stub:true`, `project:null`, `phases:[]`.
- `cli/install.js` `seedStarterPlanning()` — `INSTALL STUB` HTML banner on each .planning/*.md so accidental commits look visibly wrong; state shell mirrors the new template.
- `rihal/workflows/new-project.md` Step 0.5 — calls `rihal-tools project-status` instead of grepping JSON; classifies into `none/stub/real`; supports `--force` / `--reinit`; creates `pre-rihal-rewrite-<ts>` rollback tag before overwriting real state; error message lists `--force` and `rcode install --reset` as escape hatches.
- `rihal/bin/rihal-tools.cjs` — new `project-status` subcommand, single source of truth.
- `package.json` 3.4.20 → 3.4.21 (already published to npm).
- `CHANGELOG.md` v3.4.21 entry.

## Test plan

- [x] Fresh install on `/tmp/rihal-test-stub2` — health check passes (41 agents, 104 commands, 120 skills via global fallback).
- [x] `state.json` shape verified: `_seeded_stub:true`, `project:null`, `phases:[]`.
- [x] `rihal-tools project-status` returns `stub` on fresh install.
- [x] After `touch .planning/REQUIREMENTS.md` it returns `real`.
- [x] `node -c` on `cli/install.js` and `rihal/bin/rihal-tools.cjs`.
- [x] `npm publish 3.4.21` — live on registry, end-to-end install verified.
- [x] CI test failures verified pre-existing on main (same set fails on `b307ff85` HEAD).

## Notes

- All test-suite failures shown by CI are pre-existing on main (`gh run list --branch main` confirms `test` job already failing on the 3.4.20 release commit). This PR does not introduce regressions.
- `Semantic PR` check fails with "Resource not accessible by integration" — pre-existing infra/permissions issue, unrelated to this PR.