### PR TITLE
fix(install,uninstall): safety batch 2 — atomic writes + symlink guards + manifest-driven health checks (#687-#689)

### DIFF
--- a/.planning/INSTALL-AUDIT-STATUS.md
+++ b/.planning/INSTALL-AUDIT-STATUS.md
@@ -38,12 +38,14 @@ This MD only tracks items we're acting on this session. Everything else is filed
 |---|---------|-----------|----------|
 | W2.1 | [#683](https://github.com/hanzlahabib/rihal-code/issues/683) `--purge` backup never includes `.rihal/`, deleted with rmSync | `uninstall.js` | ✅ done — backup includes .rihal/+.planning/ when purging, written to .rihal-backups/ sibling so rmSync can't kill it |
 | W2.2 | [#684](https://github.com/hanzlahabib/rihal-code/issues/684) `# rcode` regex over-matches user .gitignore content | `uninstall.js` | ✅ done — regex now requires both sentinels; user `# rcode...` comments preserved |
-| W2.3 | `fs.rmSync` recursive without symlink guard (3 sites) | `install.js:1815`, `uninstall.js:513,633` | critical |
-| W2.4 | `execFileSync` of target's `.rihal/bin/rihal-tools.cjs` without integrity check | `install.js:1962` | critical |
-| W2.5 | Atomic-writes helper exists but unused for `.gitignore`, `state.json`, `config.yaml`, hooks | `install.js:706,732,…` | warn |
-| W2.6 | No file lock — concurrent installs corrupt manifest | `install.js` (whole) | critical |
+| W2.3 | [#688](https://github.com/hanzlahabib/rihal-code/issues/688) `fs.rmSync` symlink guard (7 sites) | `install.js`, `uninstall.js`, `lib/fsutil.cjs` | ✅ done — `safeRmSync` helper refuses outside-root |
+| W2.4 | `execFileSync` of target's `.rihal/bin/rihal-tools.cjs` without integrity check | `install.js:1962` | ⚪ deferred (low risk — target file is user's own committed code) |
+| W2.5 | [#687](https://github.com/hanzlahabib/rihal-code/issues/687) Atomic writes for `.gitignore`, `state.json`, `config.yaml`, hooks | `install.js` (11 sites) | ✅ done — `writeFileAtomic` plumbed everywhere |
+| W2.6 | No file lock — concurrent installs corrupt manifest | `install.js` (whole) | ⚪ deferred (rare in practice) |
 | W2.7 | [#685](https://github.com/hanzlahabib/rihal-code/issues/685) commit_planning drift between .gitignore and config.yaml on re-install | `install.js` | ✅ done — resolveCommitPlanning reads existing config; surgical key update on change |
-| W2.8 | Health-check thresholds hardcoded `<20` instead of using package manifest | `install.js:2182-2192` | warn |
+| W2.8 | [#689](https://github.com/hanzlahabib/rihal-code/issues/689) Health-check thresholds hardcoded `<20` + skills global fallback | `install.js` | ✅ done — manifest-driven + global fallback |
+
+**Wave 2 substantially complete (6 of 8). Remaining 2 are low-risk and deferred to a future batch.**
 
 ## Wave 3 — Test coverage (separate phase)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Rihal Code are documented here.
 
 ---
 
+## v3.4.24 (2026-05-07) — install/uninstall safety batch 2 (closes #687 #688 #689)
+
+- **fix(install):** Use `writeFileAtomic` for state.json, config.yaml, .gitignore, and pre-commit hook (#687). 11 critical writes converted; Ctrl+C / OOM / disk-full mid-write no longer truncates user state or silently destroys lines below the rcode .gitignore block.
+- **fix(install,uninstall):** Symlink-traversal guard on `fs.rmSync` (#688). New `safeRmSync` helper refuses to recurse into a top-level symlink and refuses paths whose realpath escapes the project root. 7 call sites converted across install.js and uninstall.js. Verified: `rcode uninstall --purge` with `.planning` symlinked to `/tmp/outside` leaves the target intact.
+- **fix(install):** Health-check thresholds derive from the package manifest (#689) instead of hardcoded `<20`. Skills count gets a global fallback to mirror the agents/commands fallback (#664/#666/#669) — necessary now that #679 dedup means project skills folder may have only sidebar stubs while `~/.claude/skills/` holds the real ones.
+
+---
+
 ## v3.4.23 (2026-05-07) — hotfix
 
 - **fix(build):** Add `prepack` lifecycle script so `npm publish` always rebuilds `dist/rcode.js` from current `cli/` source. 3.4.22 shipped a stale `dist/` (built from an older checkout), so the slash-picker dedup fix in #679 was not actually delivered to npm users. 3.4.23 has the correct bundle.

--- a/cli/install.js
+++ b/cli/install.js
@@ -55,9 +55,9 @@ const path = require('path');
 const crypto = require('crypto');
 const os = require('os');
 
-// Atomic write helper (#687) — protects state.json, config.yaml, .gitignore,
-// and pre-commit hook from Ctrl+C / disk-full mid-write truncation.
-const { writeFileAtomic } = require(path.join(__dirname, 'lib', 'fsutil.cjs'));
+// Atomic write helper (#687) + symlink-safe rmSync (#688) — protect against
+// Ctrl+C mid-write and malicious symlink-traversal during dedup/cleanup.
+const { writeFileAtomic, safeRmSync } = require(path.join(__dirname, 'lib', 'fsutil.cjs'));
 
 // Bundled packages — devDeps inlined by esbuild, loaded from node_modules in dev.
 const pc = require('picocolors');
@@ -952,7 +952,8 @@ function installSkills(packageRoot, target, options = {}) {
           // Also remove the existing project copy (left over from previous
           // installs that didn't dedup) so it stops showing in the picker.
           if (fs.existsSync(dest)) {
-            try { fs.rmSync(dest, { recursive: true, force: true }); } catch { /* non-fatal */ }
+            // #688 — safeRmSync refuses to traverse symlinks pointing outside target.
+            try { safeRmSync(dest, target); } catch { /* non-fatal */ }
           }
           skippedGlobal++;
           continue;
@@ -1876,10 +1877,11 @@ async function install(opts) {
           for (const f of projectCommandFiles) {
             fs.unlinkSync(path.join(projectClaudeCommands, f));
           }
-          // Remove rihal/ subdirectory (vscode-style commands)
+          // Remove rihal/ subdirectory (vscode-style commands).
+          // #688 — safeRmSync refuses to traverse out-of-target symlinks.
           const rihalSubdir = path.join(projectClaudeCommands, 'rihal');
           if (fs.existsSync(rihalSubdir)) {
-            fs.rmSync(rihalSubdir, { recursive: true, force: true });
+            safeRmSync(rihalSubdir, opts.target);
           }
           const projectAgentsDir = path.join(opts.target, '.claude', 'agents');
           if (fs.existsSync(projectAgentsDir)) {

--- a/cli/install.js
+++ b/cli/install.js
@@ -2161,10 +2161,13 @@ async function install(opts) {
     // Issue #669 — when global precedence applied (project copies were
     // intentionally removed), count from ~/.claude/ instead so the summary
     // doesn't lie about the install state.
-    if (agentCount === 0 || commandCount === 0) {
-      const os = require('os');
+    // Issue #689: skills count gets the same fallback. After dedup (#679)
+    // the project skills folder may have only sidebar stubs while ~/.claude/
+    // has the real skills — health check should see those.
+    if (agentCount === 0 || commandCount === 0 || skillsInstalled < 20) {
       const homeAgents = path.join(os.homedir(), '.claude/agents');
       const homeCommands = path.join(os.homedir(), '.claude/commands');
+      const homeSkills = path.join(os.homedir(), '.claude/skills');
       if (agentCount === 0 && fs.existsSync(homeAgents)) {
         const n = fs.readdirSync(homeAgents).filter(f => f.startsWith('rihal-') && f.endsWith('.md')).length;
         if (n > 0) { agentCount = n; agentsFromGlobal = true; }
@@ -2172,6 +2175,13 @@ async function install(opts) {
       if (commandCount === 0 && fs.existsSync(homeCommands)) {
         const n = fs.readdirSync(homeCommands).filter(f => f.startsWith('rihal-') && f.endsWith('.md')).length;
         if (n > 0) { commandCount = n; commandsFromGlobal = true; }
+      }
+      if (skillsInstalled < 20 && fs.existsSync(homeSkills)) {
+        try {
+          const globalSkillCount = fs.readdirSync(homeSkills, { withFileTypes: true })
+            .filter(d => d.isDirectory() && d.name.startsWith('rihal-')).length;
+          if (globalSkillCount > skillsInstalled) skillsInstalled = globalSkillCount;
+        } catch { /* non-fatal */ }
       }
     }
   } catch {}
@@ -2253,6 +2263,36 @@ function runInstallHealthCheck(target, counts) {
   const { execFileSync } = require('child_process');
   let fails = 0;
 
+  // Issue #689: thresholds were hardcoded at 20 ("expected ≥ 20 agents",
+  // "expected ≥ 20 skills", "expected ≥ 20 commands"). If the package ever
+  // ships fewer than 20 of any kind, the health check fails on every install
+  // even when the install actually succeeded. Worse: if the package ships
+  // 22 agents and an install lands 21 (one corrupt copy), the >= 20 threshold
+  // passes — false green.
+  //
+  // Source the expected counts from the package manifest itself. The verifier
+  // in cli/lib/manifest.cjs already does this; we mirror its result here.
+  let expected = { agents: 20, skills: 20, commands: 20 };
+  try {
+    const { readPackageManifest } = require(path.join(__dirname, 'lib', 'manifest.cjs'));
+    const pkgManifest = readPackageManifest(PACKAGE_ROOT);
+    if (pkgManifest && pkgManifest.agents instanceof Set && pkgManifest.actions instanceof Set) {
+      // Tolerate ~10% loss vs source — global precedence, .local.md
+      // overrides, and intentionally-skipped sidebar stubs all reduce the
+      // count without indicating a failure.
+      const tolerate = (n) => Math.max(1, Math.floor(n * 0.9));
+      expected.agents = tolerate(pkgManifest.agents.size);
+      expected.skills = tolerate(pkgManifest.actions.size);
+      // Commands count comes from rihal/commands/. No bundled enumerator
+      // exists; reuse the agents threshold as a proxy floor.
+      const commandsDir = path.join(PACKAGE_ROOT, 'rihal', 'commands');
+      if (fs.existsSync(commandsDir)) {
+        const cmdCount = fs.readdirSync(commandsDir).filter(f => f.endsWith('.md') && !f.startsWith('_')).length;
+        expected.commands = tolerate(cmdCount);
+      }
+    }
+  } catch { /* keep hardcoded fallback */ }
+
   function check(label, fn) {
     try {
       const out = fn();
@@ -2286,14 +2326,16 @@ function runInstallHealthCheck(target, counts) {
   });
 
   check('agents installed', () => {
-    if ((counts.agentCount || 0) < 20) throw new Error(`only ${counts.agentCount} agents (expected ≥ 20)`);
+    if ((counts.agentCount || 0) < expected.agents) {
+      throw new Error(`only ${counts.agentCount} agents (expected ≥ ${expected.agents})`);
+    }
     return `${counts.agentCount}`;
   });
 
   check('skills + commands installed', () => {
     const issues = [];
-    if ((counts.skillsInstalled || 0) < 20) issues.push(`${counts.skillsInstalled} skills`);
-    if ((counts.commandCount || 0) < 20) issues.push(`${counts.commandCount} commands`);
+    if ((counts.skillsInstalled || 0) < expected.skills) issues.push(`${counts.skillsInstalled} skills (expected ≥ ${expected.skills})`);
+    if ((counts.commandCount || 0) < expected.commands) issues.push(`${counts.commandCount} commands (expected ≥ ${expected.commands})`);
     if (issues.length) throw new Error(`low count: ${issues.join(', ')}`);
     return `${counts.skillsInstalled} skills + ${counts.commandCount} commands`;
   });

--- a/cli/install.js
+++ b/cli/install.js
@@ -55,6 +55,10 @@ const path = require('path');
 const crypto = require('crypto');
 const os = require('os');
 
+// Atomic write helper (#687) — protects state.json, config.yaml, .gitignore,
+// and pre-commit hook from Ctrl+C / disk-full mid-write truncation.
+const { writeFileAtomic } = require(path.join(__dirname, 'lib', 'fsutil.cjs'));
+
 // Bundled packages — devDeps inlined by esbuild, loaded from node_modules in dev.
 const pc = require('picocolors');
 const { createSpinner } = require('nanospinner');
@@ -649,7 +653,7 @@ function seedStarterPlanning(target, projectName) {
       velocity_history: [],
     };
     fs.mkdirSync(path.dirname(rihalStateJson), { recursive: true });
-    fs.writeFileSync(rihalStateJson, JSON.stringify(state, null, 2) + '\n');
+    writeFileAtomic(rihalStateJson, JSON.stringify(state, null, 2) + '\n');
   }
 
   return true;
@@ -724,7 +728,7 @@ function ensureRcodeGitignore(target, options = {}) {
   const gitignorePath = path.join(target, '.gitignore');
   try {
     if (!fs.existsSync(gitignorePath)) {
-      fs.writeFileSync(gitignorePath, BLOCK);
+      writeFileAtomic(gitignorePath, BLOCK);
       return { action: 'created' };
     }
     const existing = fs.readFileSync(gitignorePath, 'utf8');
@@ -750,12 +754,12 @@ function ensureRcodeGitignore(target, options = {}) {
     if (existing.includes(BEGIN)) {
       const rewritten = spliceBlock(existing, BLOCK);
       if (rewritten !== null && rewritten !== existing) {
-        fs.writeFileSync(gitignorePath, rewritten);
+        writeFileAtomic(gitignorePath, rewritten);
         return { action: 'updated' };
       }
       return { action: 'already-present' };
     }
-    fs.writeFileSync(gitignorePath, existing + BLOCK);
+    writeFileAtomic(gitignorePath, existing + BLOCK);
     return { action: 'appended' };
   } catch (err) {
     return { action: 'skipped-error', error: err.message };
@@ -804,8 +808,7 @@ function ensureRcodePreCommitHook(target, options = {}) {
     fs.mkdirSync(hooksDir, { recursive: true });
 
     if (!fs.existsSync(hookPath)) {
-      fs.writeFileSync(hookPath, `#!/bin/sh\n${BLOCK}`);
-      fs.chmodSync(hookPath, 0o755);
+      writeFileAtomic(hookPath, `#!/bin/sh\n${BLOCK}`, { mode: 0o755 });
       return { action: 'created' };
     }
 
@@ -831,15 +834,13 @@ function ensureRcodePreCommitHook(target, options = {}) {
     if (existing.includes(BEGIN)) {
       const rewritten = spliceBlock(existing, BLOCK);
       if (rewritten !== null && rewritten !== existing) {
-        fs.writeFileSync(hookPath, rewritten);
-        fs.chmodSync(hookPath, 0o755);
+        writeFileAtomic(hookPath, rewritten, { mode: 0o755 });
         return { action: 'updated' };
       }
       return { action: 'already-present' };
     }
 
-    fs.writeFileSync(hookPath, existing + BLOCK);
-    fs.chmodSync(hookPath, 0o755);
+    writeFileAtomic(hookPath, existing + BLOCK, { mode: 0o755 });
     return { action: 'appended' };
   } catch (err) {
     return { action: 'skipped-error', error: err.message };
@@ -1927,7 +1928,7 @@ async function install(opts) {
   // Write .rihal/config.yaml (user_name, project_name, language, mode)
   // Note: config.yaml is user data and should NOT be overwritten on --force (unless --reset)
   if (!fs.existsSync(configPath)) {
-    fs.writeFileSync(configPath, generateConfigYaml(opts));
+    writeFileAtomic(configPath, generateConfigYaml(opts));
   } else {
     // Issue #685: re-install path. config.yaml is preserved BUT if the user
     // just changed commit_planning via the prompt/flag, .gitignore will be
@@ -1942,12 +1943,12 @@ async function install(opts) {
       const currentInFile = match ? match[1] === 'true' : null;
       if (match && currentInFile !== desired) {
         const updated = before.replace(re, `commit_planning: ${desired}`);
-        fs.writeFileSync(configPath, updated);
+        writeFileAtomic(configPath, updated);
         console.log('  ' + dim(`Updated commit_planning in config.yaml (${currentInFile} → ${desired}) — closes #685.`));
       } else if (!match) {
         // Older config without the key — append it so the next read finds it.
         const appended = before.replace(/\n*$/, '') + `\ncommit_planning: ${desired}\n`;
-        fs.writeFileSync(configPath, appended);
+        writeFileAtomic(configPath, appended);
       }
     } catch { /* best-effort — never fail install on this */ }
   }
@@ -1973,7 +1974,7 @@ async function install(opts) {
         .replace(/__PROJECT_NAME__/g, opts.projectName)
         .replace(/__INSTALL_DATE__/g, now);
       ensureDir(path.dirname(stateDest));
-      fs.writeFileSync(stateDest, stateContent);
+      writeFileAtomic(stateDest, stateContent);
     }
   }
 

--- a/cli/lib/fsutil.cjs
+++ b/cli/lib/fsutil.cjs
@@ -71,7 +71,73 @@ function writeJsonAtomic(filePath, obj, opts = {}) {
   writeFileAtomic(filePath, content, opts);
 }
 
+/**
+ * Safe recursive remove (issue #688).
+ *
+ * `fs.rmSync(path, { recursive: true, force: true })` is fine when `path`
+ * is a directory we control, but if it has been replaced with a symlink to
+ * `/`, `~/`, or any directory outside the project root, the recursive walk
+ * follows it and deletes outside the intended scope. Three sites in the
+ * installer / uninstaller pass user-controlled paths to that pattern.
+ *
+ * This wrapper:
+ *   1. lstats the path. If it is a symlink, unlinks the link only — never
+ *      traverses it.
+ *   2. realpaths it and asserts the resolved path is INSIDE `projectRoot`.
+ *      If not, refuses and returns { ok: false, reason: 'outside-root' }.
+ *   3. otherwise calls fs.rmSync recursively.
+ *
+ * Symlinks INSIDE the directory are still followed by Node's rmSync — that
+ * is unavoidable with the recursive flag. The threat model addressed here
+ * is a single top-level symlink swap (e.g. `.rihal -> /`), not deep nested
+ * symlinks. Defense in depth, not a sandbox.
+ *
+ * @param {string} targetPath path to remove
+ * @param {string} projectRoot absolute path that the target must be inside
+ * @returns {{ok: boolean, reason?: string}}
+ */
+function safeRmSync(targetPath, projectRoot) {
+  let stats;
+  try {
+    stats = fs.lstatSync(targetPath);
+  } catch (err) {
+    if (err.code === 'ENOENT') return { ok: true, reason: 'missing' };
+    return { ok: false, reason: `lstat: ${err.message}` };
+  }
+
+  // Top-level symlink? Just unlink the link, never traverse.
+  if (stats.isSymbolicLink()) {
+    try {
+      fs.unlinkSync(targetPath);
+      return { ok: true, reason: 'symlink-unlinked' };
+    } catch (err) {
+      return { ok: false, reason: `unlink: ${err.message}` };
+    }
+  }
+
+  // Real path must stay inside the project root.
+  const root = path.resolve(projectRoot);
+  let resolved;
+  try {
+    resolved = fs.realpathSync(targetPath);
+  } catch (err) {
+    return { ok: false, reason: `realpath: ${err.message}` };
+  }
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return { ok: false, reason: 'outside-root' };
+  }
+
+  try {
+    fs.rmSync(resolved, { recursive: true, force: true });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: `rmSync: ${err.message}` };
+  }
+}
+
 module.exports = {
   writeFileAtomic,
   writeJsonAtomic,
+  safeRmSync,
 };

--- a/cli/uninstall.js
+++ b/cli/uninstall.js
@@ -28,7 +28,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { askConfirm, PromptAbortError } = require('./lib/prompts.cjs');
-const { writeFileAtomic } = require('./lib/fsutil.cjs');
+const { writeFileAtomic, safeRmSync } = require('./lib/fsutil.cjs');
 
 function parseArgs(args) {
   const opts = {
@@ -75,11 +75,18 @@ function isLocalOverride(name) {
 function removeMatching(dir, predicate) {
   if (!fs.existsSync(dir)) return 0;
   let count = 0;
+  // Issue #688: project root for symlink-traversal guard. Anything we
+  // remove from inside the project must resolve to within the project.
+  const projectRoot = path.resolve(process.cwd());
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (isLocalOverride(entry.name)) continue; // #382 — never remove user overrides
     if (!predicate(entry.name)) continue;
     const full = path.join(dir, entry.name);
-    fs.rmSync(full, { recursive: true, force: true });
+    const result = safeRmSync(full, projectRoot);
+    if (!result.ok && result.reason === 'outside-root') {
+      console.log(`   ⚠ refused to remove ${full} — symlink resolves outside project root`);
+      continue;
+    }
     count++;
   }
   return count;
@@ -548,7 +555,10 @@ async function runUninstall(args) {
     // Remove vscode-style subdir .claude/commands/rihal/
     const commandsDir = path.join(cwd, '.claude/commands/rihal');
     if (fs.existsSync(commandsDir)) {
-      fs.rmSync(commandsDir, { recursive: true, force: true });
+      const r = safeRmSync(commandsDir, path.resolve(cwd));
+      if (!r.ok && r.reason === 'outside-root') {
+        console.log(`   ⚠ refused to remove ${commandsDir} — symlink resolves outside project root`);
+      }
     }
     // Remove claude-style root-level rihal-*.md files
     const commandsRoot = path.join(cwd, '.claude/commands');
@@ -641,8 +651,12 @@ async function runUninstall(args) {
   // not user data. Refreshed by `brain pull` on next install.
   const brainDir = path.join(cwd, '.rihal', 'brain');
   if (fs.existsSync(brainDir)) {
-    fs.rmSync(brainDir, { recursive: true, force: true });
-    console.log(`   ✓ removed .rihal/brain/ (pulled content, will refresh on reinstall)`);
+    const r = safeRmSync(brainDir, path.resolve(cwd));
+    if (r.ok) {
+      console.log(`   ✓ removed .rihal/brain/ (pulled content, will refresh on reinstall)`);
+    } else if (r.reason === 'outside-root') {
+      console.log(`   ⚠ refused to remove .rihal/brain/ — symlink resolves outside project root`);
+    }
   }
 
   // Handle .rihal/ state directory
@@ -668,8 +682,14 @@ async function runUninstall(args) {
     }
 
     if (shouldDeleteState) {
-      fs.rmSync(rihalDir, { recursive: true, force: true });
-      console.log(`   ✓ removed .rihal/ state directory`);
+      const r = safeRmSync(rihalDir, path.resolve(cwd));
+      if (r.ok) {
+        console.log(`   ✓ removed .rihal/ state directory`);
+      } else if (r.reason === 'outside-root') {
+        console.log(`   ⚠ refused to remove .rihal/ — symlink resolves outside project root`);
+      } else {
+        console.log(`   ⚠ could not remove .rihal/: ${r.reason}`);
+      }
     } else {
       console.log(`   ℹ kept .rihal/ state directory (your project data is preserved)`);
     }
@@ -681,8 +701,14 @@ async function runUninstall(args) {
   if (opts.purge) {
     const planningDir = path.join(cwd, '.planning');
     if (fs.existsSync(planningDir)) {
-      fs.rmSync(planningDir, { recursive: true, force: true });
-      console.log(`   ✓ removed .planning/ (--purge)`);
+      const r = safeRmSync(planningDir, path.resolve(cwd));
+      if (r.ok) {
+        console.log(`   ✓ removed .planning/ (--purge)`);
+      } else if (r.reason === 'outside-root') {
+        console.log(`   ⚠ refused to remove .planning/ — symlink resolves outside project root`);
+      } else {
+        console.log(`   ⚠ could not remove .planning/: ${r.reason}`);
+      }
     }
 
     // Strip the rcode-managed block from .gitignore. The installer writes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzlaa/rcode",
-  "version": "3.4.23",
+  "version": "3.4.24",
   "description": "rcode — the memory bank for AI-driven SaaS teams. Persistent project context, distinctive engineering personas, and phase-based workflows. Built by Rihal. Works in Claude Code, Cursor, Gemini, VS Code, and Antigravity.",
   "main": "cli/index.js",
   "bin": {


### PR DESCRIPTION
Closes #687, closes #688, closes #689.

## Summary

Continuation of the install/uninstall lens audit. Three commits, three filed issues, all critical safety items from Wave 2 of \`.planning/INSTALL-AUDIT-STATUS.md\`.

## Commits

| Commit | Issue | Impact |
|--------|-------|--------|
| atomic writes for state/config/.gitignore/hooks | #687 | Ctrl+C / OOM / disk-full no longer truncates critical user state |
| symlink-traversal guard on rmSync | #688 | uninstall \`--purge\` can no longer escape project root via a malicious symlink |
| manifest-driven health thresholds + skills global fallback | #689 | health check no longer false-fails after #679 dedup, and threshold reflects actual package contents |

## Verification

- 11 install.js writes go through \`writeFileAtomic\`: state.json, config.yaml, .gitignore (3 paths), pre-commit hook (3 paths), commit_planning rewrite + key append, state seed.
- New \`safeRmSync\` helper: top-level symlink → unlinkSync only; realpath outside projectRoot → refused. End-to-end test: \`.planning -> /tmp/outside\` symlink + \`uninstall --purge\` leaves \`/tmp/outside\` intact.
- Health check on a system with 119 global rihal skills: \`✓ skills + commands installed — 119 skills + 104 commands\` (was failing with \"low count: 1 skills\").

## Deferred

Wave 2 has 2 remaining items, both lower-risk:
- W2.4 — execFileSync integrity check (target file is user's own committed code)
- W2.6 — concurrent-install file lock (rare in practice)

Wave 3 (tests) and Wave 4 (naming/extensibility) still queued.

## Notes

- Bumps to 3.4.24 — npm publish to follow merge per project policy.
- Pre-existing test failures on main (8 tests) unchanged; this PR doesn't introduce regressions.