### PR TITLE
fix(test,lib/manifest): green the test suite — 241/241 passing (#699)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ If a user says "just keep going" or "don't stop until done", that authorization 
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type(scope): subject`
 - Types allowed: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `revert`
-- Scopes allowed: `agents`, `skills`, `workflows`, `templates`, `dashboard`, `docs`, `config`, `github`, `commands`, `memory`, `brand`, `cli`, `ci`, `release`, `meta`, `tasks`, `migrations`, `refs`, `state`, `hooks`, `install`, `parity`, `triggers`, `dogfood`, `namespace`, `planning`, `insights`, `help`, `roadmap`, `session`, `audits`, `execute`, `executor`, `plan`, `planner`, `readme`, `sync`, `sprint`, `agent-exp`, `extensibility`, `lens-audit`, `tiers`, plus numeric phase/sprint scopes (e.g. `docs(15)`, `feat(8.3)`)
+- Scopes allowed: `agents`, `skills`, `workflows`, `templates`, `dashboard`, `docs`, `config`, `github`, `commands`, `memory`, `brand`, `cli`, `ci`, `release`, `meta`, `tasks`, `migrations`, `refs`, `state`, `hooks`, `install`, `parity`, `triggers`, `dogfood`, `namespace`, `planning`, `insights`, `help`, `roadmap`, `session`, `audits`, `execute`, `executor`, `plan`, `planner`, `readme`, `sync`, `sprint`, `agent-exp`, `extensibility`, `lens-audit`, `tiers`, `build`, `council`, `doctor`, `postinstall`, `progress`, `security`, `tools`, `uninstall`, `test`, plus numeric phase/sprint scopes (e.g. `docs(15)`, `feat(8.3)`)
 - Subject: lowercase first letter, imperative mood, no trailing period, under 72 chars
 - **NEVER add Claude/AI attribution to commit messages.** No "Generated with Claude Code", no "Co-Authored-By: Claude", no "🤖 Generated". The user does not want this.
 - **NEVER use `--no-verify`** to bypass hooks. If hooks fail, fix the underlying issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Rihal Code are documented here.
 
 ---
 
+## v3.4.28 (2026-05-07) — green test suite (closes #698)
+
+- **fix(test):** Make pre-existing test failures aware of the #679 dedup reality. After globals shadow project skills, tests that count `./.claude/skills/` etc. would erroneously fail with "0 found". Fall back to `~/.claude/` mirroring the runtime behavior. Touches `agent-size-budget`, `skill-description-budget`, `help-md-parity`, `no-absolute-home-paths`.
+- **fix(lib/manifest):** `verifyClaudeInstall` had a pre-existing bug where the actions filter `!n.startsWith('rihal-')` excluded ALL real installed actions (since `installSkills` prefixes every action with `rihal-`). Rewrote to compare against the prefixed package set directly. Drift detection now actually works.
+- **fix(test):** `manifest.test.cjs` was seeding `.claude/skills/rihal-X` for agents — but the post-v3 layout puts agents at `.claude/agents/rihal-X.md`. Updated the two drift tests to match.
+- **feat(lib/manifest):** Added `{ globalFallback: false }` option to `verifyClaudeInstall` so tests can isolate from the contributor's real `~/.claude/`. Default remains true to preserve runtime behavior.
+- **fix(test):** `no-source-command-skill-dupes` now exempts the 6 phase-flow commands (`rihal-sprint-planning`, `rihal-dev-story`, etc.) that legitimately ship as both real skills and sidebar entries — matching the generator's runtime behavior.
+- **fix(meta):** AGENTS.md + CONTRIBUTING.md scope lists synced. New scopes added: `build`, `council`, `doctor`, `postinstall`, `progress`, `security`, `test`, `tools`, `uninstall` (all already used in commits).
+
+**Net: full suite goes from 231/241 → 241/241 passing.**
+
+---
+
 ## v3.4.27 (2026-05-07) — install/uninstall batch 4 (closes #696 #697)
 
 - **test(uninstall,postinstall,update):** 38 new tests for the previously-untested CLI modules (#696). Closes Wave 3 W3.2/W3.3/W3.4 from `.planning/INSTALL-AUDIT-STATUS.md`. Refactors three files for testability: `cli/postinstall.js` now wraps top-level effect in `require.main === module` so importing it doesn't fire the postinstall logic; `cli/uninstall.js` extracts the gitignore-strip regex into pure `stripRihalGitignoreBlock`; `cli/update.js` adds named exports for `parseArgs` and `detectInstalledEditors`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,6 +298,15 @@ We use [Conventional Commits](https://www.conventionalcommits.org/) format. The 
 - `extensibility` — extensibility and plugin hooks
 - `lens-audit` — 15-lens audit system and lenses
 - `tiers` — TIERS.md and tier-related documentation
+- `build` — `scripts/build.cjs`, esbuild config, bundle artifacts
+- `council` — `/rihal-council` workflow + spawning logic
+- `doctor` — `cli/doctor.js` health checks
+- `postinstall` — `cli/postinstall.js` lifecycle hook
+- `progress` — `/rihal-progress` workflow
+- `security` — security guardrails (symlink guards, integrity checks)
+- `test` — test files under `test/` (test-only changes)
+- `tools` — `rihal/bin/rihal-tools.cjs` subcommands
+- `uninstall` — `cli/uninstall.js` flow
 - `<phase-id>` — numeric phase scope when committing inside a phase (e.g. `docs(15)`, `feat(8.3)`)
 - `<sprint-id>` — numeric sprint scope inside a phase (e.g. `feat(15.1)`)
 

--- a/cli/lib/manifest.cjs
+++ b/cli/lib/manifest.cjs
@@ -109,7 +109,12 @@ function diffSet(editor, kind, expected, installed) {
  * makes doctor report drift like "agents 119/23" when nothing is wrong.
  * That's why the agent count comes from .claude/agents/, not .claude/skills/.
  */
-function verifyClaudeInstall(cwd, packageRoot) {
+function verifyClaudeInstall(cwd, packageRoot, options = {}) {
+  // Issue #698: tests assert against an isolated tempdir cwd. The global
+  // fallback (#664) makes that impossible because it reads the contributor's
+  // real ~/.claude/. Tests can pass { globalFallback: false } to disable it.
+  // Default remains true to preserve the runtime behavior introduced in #664.
+  const globalFallback = options.globalFallback !== false;
   const pkg = readPackageManifest(packageRoot);
   const agentsDir = path.join(cwd, '.claude/agents');
   const skillsDir = path.join(cwd, '.claude/skills');
@@ -129,7 +134,7 @@ function verifyClaudeInstall(cwd, packageRoot) {
   // level .claude/agents/rihal-*.md when the user's ~/.claude/ already has
   // them, to avoid duplicate commands. Without this fallback the verifier
   // reports 0 agents on every successful install in that scenario.
-  if (installedAgents.size === 0) {
+  if (installedAgents.size === 0 && globalFallback) {
     try {
       const os = require('os');
       const globalAgentsDir = path.join(os.homedir(), '.claude/agents');
@@ -143,12 +148,13 @@ function verifyClaudeInstall(cwd, packageRoot) {
     } catch { /* non-fatal — permission errors etc. */ }
   }
 
-  // Actions: .claude/skills/<bare-name>/ — exclude rihal-* dirs (those are
-  // either agent stubs or command stubs, never action skills).
+  // Actions: .claude/skills/rihal-<name>/. installSkills (cli/install.js)
+  // prefixes every action with rihal-, and readPackageManifest does the
+  // same — so both sides are normalized. The previous version filtered OUT
+  // rihal-* dirs which excluded ALL real actions and made the diff always
+  // report "everything missing." Compare directly against the prefixed set.
   const allInstalled = readInstalledDirs(skillsDir);
-  const actionsInstalled = new Set(
-    [...allInstalled].filter((n) => !n.startsWith('rihal-'))
-  );
+  const actionsInstalled = new Set([...allInstalled].filter((n) => pkg.actions.has(n)));
 
   return [
     diffSet('claude', 'agents', pkg.agents, installedAgents),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzlaa/rcode",
-  "version": "3.4.27",
+  "version": "3.4.28",
   "description": "rcode — the memory bank for AI-driven SaaS teams. Persistent project context, distinctive engineering personas, and phase-based workflows. Built by Rihal. Works in Claude Code, Cursor, Gemini, VS Code, and Antigravity.",
   "main": "cli/index.js",
   "bin": {

--- a/test/agent-size-budget.test.cjs
+++ b/test/agent-size-budget.test.cjs
@@ -22,21 +22,42 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
-const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
+const PROJECT_AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
+const GLOBAL_AGENTS_DIR = path.join(os.homedir(), '.claude', 'agents');
 
 const XL_HARD_CAP = 1600; // fail
 const L_WARN = 1000;       // log
 const M_WARN = 500;        // log
 
+/**
+ * Resolve which agents directory to read from. After #679 dedup, the
+ * project's .claude/agents/ may be empty when ~/.claude/agents/ already
+ * has the rihal-* set (global precedence). Mirror the runtime fallback.
+ */
+function resolveAgentsDir() {
+  if (fs.existsSync(PROJECT_AGENTS_DIR)) {
+    const has = fs.readdirSync(PROJECT_AGENTS_DIR).some(f => f.startsWith('rihal-') && f.endsWith('.md'));
+    if (has) return PROJECT_AGENTS_DIR;
+  }
+  if (fs.existsSync(GLOBAL_AGENTS_DIR)) {
+    const has = fs.readdirSync(GLOBAL_AGENTS_DIR).some(f => f.startsWith('rihal-') && f.endsWith('.md'));
+    if (has) return GLOBAL_AGENTS_DIR;
+  }
+  return null;
+}
+
 function classify() {
-  if (!fs.existsSync(AGENTS_DIR)) return { entries: [] };
+  const dir = resolveAgentsDir();
+  if (!dir) return { entries: [] };
   const entries = [];
-  for (const f of fs.readdirSync(AGENTS_DIR)) {
+  for (const f of fs.readdirSync(dir)) {
     if (!f.endsWith('.md')) continue;
-    const text = fs.readFileSync(path.join(AGENTS_DIR, f), 'utf8');
+    if (!f.startsWith('rihal-')) continue; // skip non-rihal agents in global dir
+    const text = fs.readFileSync(path.join(dir, f), 'utf8');
     const lines = text.split('\n').length;
     let tier = 'OK';
     if (lines > XL_HARD_CAP) tier = 'XL';

--- a/test/help-md-parity.test.cjs
+++ b/test/help-md-parity.test.cjs
@@ -21,10 +21,22 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 
+const os = require('node:os');
+
 const PROJECT_ROOT = path.resolve(__dirname, '..');
 const HELP_MD = path.join(PROJECT_ROOT, 'rihal', 'workflows', 'help.md');
 const COMMANDS_DIR = path.join(PROJECT_ROOT, 'rihal', 'commands');
-const SKILLS_DIR = path.join(PROJECT_ROOT, '.claude', 'skills');
+// Source skills (always present in repo) and installed skills (project OR
+// global, post-#679 dedup may leave project empty).
+const SOURCE_SKILLS_DIRS = [
+  path.join(PROJECT_ROOT, 'rihal', 'skills', 'agents'),
+  path.join(PROJECT_ROOT, 'rihal', 'skills', 'actions'),
+  path.join(PROJECT_ROOT, 'rihal', 'skills', 'core'),
+];
+const INSTALLED_SKILLS_DIRS = [
+  path.join(PROJECT_ROOT, '.claude', 'skills'),
+  path.join(os.homedir(), '.claude', 'skills'),
+];
 
 // Commands explicitly annotated in help.md as not yet implemented are
 // allowed to be missing. The annotation marker is stable text; the test
@@ -50,10 +62,23 @@ function extractAdvertisedCommands(text) {
 }
 
 function commandHasSource(name) {
+  // Command file in source repo
   const cmdFile = path.join(COMMANDS_DIR, `${name}.md`);
   if (fs.existsSync(cmdFile)) return true;
-  const skillDir = path.join(SKILLS_DIR, `rihal-${name}`);
-  if (fs.existsSync(skillDir) && fs.statSync(skillDir).isDirectory()) return true;
+  // Source skill dir (rihal/skills/<bucket>/rihal-<name>/ or <name>/)
+  for (const bucketDir of SOURCE_SKILLS_DIRS) {
+    if (!fs.existsSync(bucketDir)) continue;
+    if (fs.existsSync(path.join(bucketDir, `rihal-${name}`))) return true;
+    if (fs.existsSync(path.join(bucketDir, name))) return true;
+  }
+  // Installed skill dir (project OR global — covers #679 dedup state)
+  for (const dir of INSTALLED_SKILLS_DIRS) {
+    if (!fs.existsSync(dir)) continue;
+    const target = path.join(dir, `rihal-${name}`);
+    try {
+      if (fs.existsSync(target) && fs.statSync(target).isDirectory()) return true;
+    } catch { /* skip */ }
+  }
   return false;
 }
 

--- a/test/helpers.cjs
+++ b/test/helpers.cjs
@@ -69,10 +69,45 @@ function registerCleanup(t, dir) {
   t.after(() => cleanup(dir));
 }
 
+/**
+ * Mirror the runtime global-precedence fallback that install.js uses
+ * (#664/#666/#669 for agents/commands, #689 for skills). When the project
+ * .claude/ dir is empty because globals shadow it (#679 dedup), tests that
+ * count installed rihal-* artifacts should look at ~/.claude/ instead.
+ *
+ * Returns the count from project first; falls back to global only if
+ * project has 0. Returns 0 when neither has anything.
+ */
+function countRihalArtifacts(projectRoot, kind) {
+  // kind: 'agents' (.md files) | 'skills' (dirs) | 'commands' (.md files)
+  const projectDir = path.join(projectRoot, '.claude', kind);
+  const globalDir = path.join(os.homedir(), '.claude', kind);
+
+  function countAt(dir) {
+    if (!fs.existsSync(dir)) return 0;
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      if (kind === 'skills') {
+        return entries.filter(e => e.isDirectory() && e.name.startsWith('rihal-')).length;
+      }
+      return entries.filter(e =>
+        e.isFile() && e.name.startsWith('rihal-') && e.name.endsWith('.md'),
+      ).length;
+    } catch {
+      return 0;
+    }
+  }
+
+  const projectCount = countAt(projectDir);
+  if (projectCount > 0) return projectCount;
+  return countAt(globalDir);
+}
+
 module.exports = {
   makeTempDir,
   cleanup,
   initRihalDir,
   seedPhase,
   registerCleanup,
+  countRihalArtifacts,
 };

--- a/test/lib/manifest.test.cjs
+++ b/test/lib/manifest.test.cjs
@@ -45,7 +45,7 @@ test('verifyClaudeInstall reports all agents missing when install dir is empty',
   const cwd = makeTempDir();
   t.after(() => cleanup(cwd));
 
-  const reports = verifyClaudeInstall(cwd, PACKAGE_ROOT);
+  const reports = verifyClaudeInstall(cwd, PACKAGE_ROOT, { globalFallback: false });
   const agentReport = reports.find((r) => r.kind === 'agents');
   assert.ok(agentReport);
   assert.strictEqual(agentReport.installedCount, 0);
@@ -58,19 +58,21 @@ test('verifyClaudeInstall reports zero drift when all expected dirs exist', (t) 
   t.after(() => cleanup(cwd));
 
   const manifest = readPackageManifest(PACKAGE_ROOT);
+  const agentsDir = path.join(cwd, '.claude/agents');
   const skillsDir = path.join(cwd, '.claude/skills');
+  fs.mkdirSync(agentsDir, { recursive: true });
   fs.mkdirSync(skillsDir, { recursive: true });
 
-  // Create a stub dir for each expected agent (rihal-{name})
+  // Agents live in .claude/agents/rihal-<name>.md as files (post-v3 layout).
   for (const agent of manifest.agents) {
-    fs.mkdirSync(path.join(skillsDir, `rihal-${agent}`));
+    fs.writeFileSync(path.join(agentsDir, `rihal-${agent}.md`), '');
   }
-  // And each expected action (bare name)
+  // Actions still live in .claude/skills/<bare-name>/ as dirs.
   for (const action of manifest.actions) {
     fs.mkdirSync(path.join(skillsDir, action));
   }
 
-  const reports = verifyClaudeInstall(cwd, PACKAGE_ROOT);
+  const reports = verifyClaudeInstall(cwd, PACKAGE_ROOT, { globalFallback: false });
   const agentReport = reports.find((r) => r.kind === 'agents');
   const actionReport = reports.find((r) => r.kind === 'actions');
 
@@ -85,17 +87,17 @@ test('verifyClaudeInstall detects drift when one agent dir is deleted', (t) => {
   t.after(() => cleanup(cwd));
 
   const manifest = readPackageManifest(PACKAGE_ROOT);
-  const skillsDir = path.join(cwd, '.claude/skills');
-  fs.mkdirSync(skillsDir, { recursive: true });
+  const agentsDir = path.join(cwd, '.claude/agents');
+  fs.mkdirSync(agentsDir, { recursive: true });
 
-  // Install every agent except the first one
+  // Install every agent except the first one (post-v3 file-based layout).
   const agents = [...manifest.agents];
   const skipped = agents[0];
   for (const agent of agents.slice(1)) {
-    fs.mkdirSync(path.join(skillsDir, `rihal-${agent}`));
+    fs.writeFileSync(path.join(agentsDir, `rihal-${agent}.md`), '');
   }
 
-  const reports = verifyClaudeInstall(cwd, PACKAGE_ROOT);
+  const reports = verifyClaudeInstall(cwd, PACKAGE_ROOT, { globalFallback: false });
   const agentReport = reports.find((r) => r.kind === 'agents');
   assert.deepStrictEqual(agentReport.missing, [skipped]);
 });

--- a/test/lib/no-absolute-home-paths.test.cjs
+++ b/test/lib/no-absolute-home-paths.test.cjs
@@ -81,15 +81,41 @@ const FORBIDDEN_PATTERNS = [
 // We don't assert on the exact set (new commands can be added) — we just
 // walk the directory and scan every `.md` file under it.
 function listSlashCommands(cwd) {
-  const dir = path.join(cwd, '.claude', 'commands', 'rihal');
-  if (!fs.existsSync(dir)) return [];
-  return fs
-    .readdirSync(dir)
-    .filter((name) => name.endsWith('.md'))
-    .map((name) => ({
-      name,
-      full: path.join(dir, name),
-    }));
+  const out = [];
+
+  // VS Code-style layout: .claude/commands/rihal/<name>.md
+  const subdir = path.join(cwd, '.claude', 'commands', 'rihal');
+  if (fs.existsSync(subdir)) {
+    for (const name of fs.readdirSync(subdir)) {
+      if (!name.endsWith('.md')) continue;
+      out.push({ name, full: path.join(subdir, name) });
+    }
+  }
+
+  // Claude Code layout: .claude/commands/rihal-<name>.md (flat)
+  const flatDir = path.join(cwd, '.claude', 'commands');
+  if (fs.existsSync(flatDir)) {
+    for (const name of fs.readdirSync(flatDir)) {
+      if (!name.startsWith('rihal-') || !name.endsWith('.md')) continue;
+      out.push({ name, full: path.join(flatDir, name) });
+    }
+  }
+
+  // After #679/#664 dedup, project commands may be removed when ~/.claude/
+  // already has the rihal-* set. Fall back to reading installed-template
+  // content from rihal/commands/ in the source repo so the cross-project-
+  // path lint can still run.
+  if (out.length === 0) {
+    const sourceDir = path.resolve(__dirname, '..', '..', 'rihal', 'commands');
+    if (fs.existsSync(sourceDir)) {
+      for (const name of fs.readdirSync(sourceDir)) {
+        if (!name.endsWith('.md') || name.startsWith('_')) continue;
+        out.push({ name: `rihal-${name}`, full: path.join(sourceDir, name) });
+      }
+    }
+  }
+
+  return out;
 }
 
 function findMatches(content, pattern) {

--- a/test/no-source-command-skill-dupes.test.cjs
+++ b/test/no-source-command-skill-dupes.test.cjs
@@ -50,12 +50,23 @@ test('no-source-command-skill-dupes: no source skill duplicates a sidebar comman
       dupes.push(`${expectedStub} (mirrors /rihal-${cmd})`);
     }
   }
-  // Some commands legitimately have real skills (init, help, code-review,
-  // debug have full skills). Those are exempted by the generator at install
-  // time. Here, list explicit exemptions matching the generator's logic.
+  // Some commands legitimately have real skills. Those are exempted by the
+  // generator at install time (cli/generate-command-skills.cjs:174 — when
+  // realSkills.has(skillName), the stub is skipped). The list below mirrors
+  // that runtime behavior so the source-tree check stays in sync with what
+  // actually ships.
   const ALLOWED_OVERLAPS = new Set([
-    'rihal-debug',         // real skill at actions/4-implementation/rihal-debug
-    'rihal-code-review',   // real skill at actions/4-implementation/rihal-code-review
+    'rihal-debug',                       // actions/4-implementation/rihal-debug
+    'rihal-code-review',                 // actions/4-implementation/rihal-code-review
+    // Phase-flow commands that ship full skills + sidebar entries — both
+    // forms are intentional. The skill is the in-IDE workflow; the command
+    // is the slash-picker shortcut. Sidebar generator skips these at install.
+    'rihal-sprint-planning',
+    'rihal-sprint-status',
+    'rihal-dev-story',
+    'rihal-create-story',
+    'rihal-create-epics-and-stories',
+    'rihal-prfaq',
   ]);
   const filtered = dupes.filter((d) => {
     const name = d.split(' ')[0];

--- a/test/skill-description-budget.test.cjs
+++ b/test/skill-description-budget.test.cjs
@@ -19,10 +19,12 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
-const SKILLS_DIR = path.join(PROJECT_ROOT, '.claude', 'skills');
+const PROJECT_SKILLS_DIR = path.join(PROJECT_ROOT, '.claude', 'skills');
+const GLOBAL_SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
 const HARD_CAP_CHARS = 100;
 
 // Snapshot: current count of skills exceeding HARD_CAP_CHARS, captured
@@ -30,12 +32,30 @@ const HARD_CAP_CHARS = 100;
 // you trim a description; never raise it.
 const BASELINE_OFFENDERS = 0;
 
+/**
+ * Resolve which skills directory has the rihal-* set. After #679 dedup,
+ * .claude/skills/ may be empty when globals shadow it. Mirror runtime
+ * fallback.
+ */
+function resolveSkillsDir() {
+  for (const dir of [PROJECT_SKILLS_DIR, GLOBAL_SKILLS_DIR]) {
+    if (!fs.existsSync(dir)) continue;
+    try {
+      const has = fs.readdirSync(dir).some(d => d.startsWith('rihal-'));
+      if (has) return dir;
+    } catch { /* continue */ }
+  }
+  return null;
+}
+
 function countOffenders() {
-  if (!fs.existsSync(SKILLS_DIR)) return { total: 0, offenders: [] };
+  const dir = resolveSkillsDir();
+  if (!dir) return { total: 0, offenders: [] };
   let total = 0;
   const offenders = [];
-  for (const d of fs.readdirSync(SKILLS_DIR)) {
-    const f = path.join(SKILLS_DIR, d, 'SKILL.md');
+  for (const d of fs.readdirSync(dir)) {
+    if (!d.startsWith('rihal-')) continue;
+    const f = path.join(dir, d, 'SKILL.md');
     if (!fs.existsSync(f)) continue;
     total++;
     const text = fs.readFileSync(f, 'utf8');
@@ -53,7 +73,7 @@ function countOffenders() {
 }
 
 test('installed skill count is non-trivial (sanity)', () => {
-  if (!fs.existsSync(SKILLS_DIR)) return; // not installed — CI without pnpm install, skip
+  if (!resolveSkillsDir()) return; // neither project nor global has rihal skills — skip
   const { total } = countOffenders();
   assert.ok(total > 50, `expected >50 skills, got ${total} — install drift?`);
 });


### PR DESCRIPTION
Closes #699.

## Summary

Audits and fixes the 10 pre-existing test failures. After this PR the suite goes from 231/241 to **241/241 green**.

## Categories of fixes

| Category | Count | Examples |
|---|---|---|
| Dedup-aware fallback in tests | 4 | `agent-size-budget`, `skill-description-budget`, `help-md-parity`, `no-absolute-home-paths` |
| Pre-existing implementation bug | 1 | `verifyClaudeInstall` actions filter excluded ALL real actions |
| Test seeded wrong layout | 1 | `manifest.test.cjs` seeded pre-v3 skills layout for agents |
| Documented intentional overlap | 1 | `no-source-command-skill-dupes` — 6 phase-flow commands |
| Meta-doc drift | 2 | `scope-history-parity`, `scope-list-parity` (AGENTS.md ↔ CONTRIBUTING.md sync) |
| Test isolation knob | 1 | `verifyClaudeInstall` got `{ globalFallback: false }` option |

## The implementation bug

`cli/lib/manifest.cjs` had:

\`\`\`js
const actionsInstalled = new Set(
  [...allInstalled].filter((n) => !n.startsWith('rihal-'))
);
\`\`\`

But `installSkills` prefixes every action with `rihal-`, and `readPackageManifest` does the same. The filter excluded all real actions and made the diff always report "everything missing." Rewrote to compare against the prefixed package set directly. Drift detection now actually works.

## Notes

- Bumps to 3.4.28.
- Status doc on main reflects: 4 of 4 waves complete (with the 3 explicitly-deferred low-risk/polish items still open as documented).