### PR TITLE
test: regression coverage for batch 5 fixes (#708 — pins #701-#706)

### DIFF
--- a/test/install-batch5-regressions.test.cjs
+++ b/test/install-batch5-regressions.test.cjs
@@ -1,0 +1,242 @@
+/**
+ * Regression tests for the batch-5 install bugs (#702, #703, #705).
+ *
+ * Each test pins the WHY of a fix that already shipped. If a future refactor
+ * silently regresses any of these, CI fails before the bad behavior hits npm.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const INSTALL_JS = path.join(REPO_ROOT, 'cli', 'install.js');
+const { makeTempDir, cleanup } = require('./helpers.cjs');
+
+function gitInit(dir) {
+  spawnSync('git', ['init', '-q'], { cwd: dir });
+}
+
+function runInstall(target, extra = []) {
+  return spawnSync('node', [INSTALL_JS, '--target', target, '--no-update-check', '--yes', ...extra], {
+    encoding: 'utf8',
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// #702 — files-manifest.csv must include skills installed by installSkills().
+// Pre-fix the manifest was generated BEFORE installSkills ran, so 100+ skill
+// files were invisible to orphan sweep + doctor drift detection.
+// ────────────────────────────────────────────────────────────────────────
+
+test('#702 — files-manifest.csv contains entries from .rihal/skills/', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+
+  const r = runInstall(dir);
+  assert.strictEqual(r.status, 0, `install failed: ${r.stderr}`);
+
+  const manifestPath = path.join(dir, '.rihal', '_config', 'files-manifest.csv');
+  assert.strictEqual(fs.existsSync(manifestPath), true, 'manifest must exist');
+
+  const content = fs.readFileSync(manifestPath, 'utf8');
+  // Internal skills always land in .rihal/skills/ and are NOT shadowed by
+  // global precedence — these MUST appear in the manifest.
+  const internalSkillRows = content.split('\n').filter(line => /^\.rihal\/skills\//.test(line));
+  assert.ok(
+    internalSkillRows.length > 0,
+    `expected manifest to contain .rihal/skills/* entries, got 0. ` +
+    `This means files-manifest.csv was generated before installSkills() ran — regression of #702.`,
+  );
+});
+
+test('#702 — manifest entries match files actually on disk under .rihal/skills/', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+  runInstall(dir);
+
+  const manifestPath = path.join(dir, '.rihal', '_config', 'files-manifest.csv');
+  const rows = fs.readFileSync(manifestPath, 'utf8').split('\n').slice(1).filter(Boolean);
+  const manifestRels = new Set(rows.map(r => r.split(',')[0]));
+
+  // Walk .rihal/skills/ and assert every file is in the manifest.
+  function walk(absDir, baseRel) {
+    if (!fs.existsSync(absDir)) return;
+    for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+      const full = path.join(absDir, entry.name);
+      const rel = path.join(baseRel, entry.name).split(path.sep).join('/');
+      if (entry.isDirectory()) {
+        walk(full, rel);
+      } else if (entry.isFile()) {
+        assert.ok(
+          manifestRels.has(rel),
+          `file ${rel} exists on disk but missing from manifest — regression of #702`,
+        );
+      }
+    }
+  }
+  walk(path.join(dir, '.rihal', 'skills'), '.rihal/skills');
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// #703 — sweepStaleInstalledFiles must refuse path-traversal CSV entries.
+// Pre-fix, a row like '../../etc/passwd,deadbeef,0' caused fs.rmSync to
+// delete outside the project root.
+// ────────────────────────────────────────────────────────────────────────
+
+test('#703 — sweep refuses CSV rows with .. path-escape segments', (t) => {
+  const dir = makeTempDir();
+  const outside = makeTempDir();
+  t.after(() => { cleanup(dir); cleanup(outside); });
+  gitInit(dir);
+
+  // First install creates the manifest so subsequent sweep has something to read.
+  runInstall(dir);
+
+  // Plant a victim file outside the project root, then add a path-escape
+  // entry to the manifest pointing at it.
+  const victim = path.join(outside, 'precious.txt');
+  fs.writeFileSync(victim, 'do not delete');
+  // Compute the relative path from project root to victim (will contain ..).
+  const escapeRel = path.relative(dir, victim);
+  assert.ok(escapeRel.includes('..'), `expected escape rel to contain .., got ${escapeRel}`);
+
+  const manifestPath = path.join(dir, '.rihal', '_config', 'files-manifest.csv');
+  fs.appendFileSync(manifestPath, `${escapeRel},deadbeef,0\n`);
+
+  // Re-run install with --force to trigger the sweep.
+  runInstall(dir, ['--force']);
+
+  // The victim file outside the project must survive.
+  assert.strictEqual(
+    fs.existsSync(victim),
+    true,
+    `victim file at ${victim} was deleted — regression of #703 (sweep escaped project root)`,
+  );
+});
+
+test('#703 — sweep refuses absolute paths from CSV', (t) => {
+  const dir = makeTempDir();
+  const outside = makeTempDir();
+  t.after(() => { cleanup(dir); cleanup(outside); });
+  gitInit(dir);
+
+  runInstall(dir);
+
+  const victim = path.join(outside, 'absolute-victim.txt');
+  fs.writeFileSync(victim, 'absolute path victim');
+
+  // Plant an ABSOLUTE path entry — different attack vector than '..'.
+  const manifestPath = path.join(dir, '.rihal', '_config', 'files-manifest.csv');
+  fs.appendFileSync(manifestPath, `${victim},deadbeef,0\n`);
+
+  runInstall(dir, ['--force']);
+
+  assert.strictEqual(
+    fs.existsSync(victim),
+    true,
+    `absolute-path victim was deleted — regression of #703`,
+  );
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// #705 — _seeded_stub:true must NOT be seeded when ROADMAP is real.
+// Pre-fix: the template state.json (which has _seeded_stub:true baked in)
+// got copied wholesale on re-install even when ROADMAP was real, mis-
+// classifying the project as fresh.
+// ────────────────────────────────────────────────────────────────────────
+
+test('#705 — fresh install with no ROADMAP gets _seeded_stub:true (baseline)', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+
+  runInstall(dir);
+
+  const state = JSON.parse(fs.readFileSync(path.join(dir, '.rihal', 'state.json'), 'utf8'));
+  assert.strictEqual(state._seeded_stub, true, 'fresh install should have _seeded_stub:true');
+});
+
+test('#705 — fresh install creates a stub-banner ROADMAP', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+  runInstall(dir);
+
+  const roadmap = fs.readFileSync(path.join(dir, '.planning', 'ROADMAP.md'), 'utf8');
+  assert.match(roadmap, /<!-- INSTALL STUB/, 'fresh ROADMAP must carry the INSTALL STUB banner');
+});
+
+test('#705 — re-install with real ROADMAP + missing state.json does NOT re-seed _seeded_stub', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+
+  // First install: stub state + stub ROADMAP.
+  runInstall(dir);
+
+  // Simulate the user replacing ROADMAP with real content + manually
+  // deleting state.json (a common reset pattern).
+  fs.writeFileSync(
+    path.join(dir, '.planning', 'ROADMAP.md'),
+    '# Real Project Roadmap\n\n## Phase 1 — Real production phase\n\nReal goal here.\n',
+  );
+  fs.unlinkSync(path.join(dir, '.rihal', 'state.json'));
+
+  // Re-install. Without the #705 guard, the template _seeded_stub:true
+  // would be copied straight back in.
+  runInstall(dir);
+
+  const state = JSON.parse(fs.readFileSync(path.join(dir, '.rihal', 'state.json'), 'utf8'));
+  assert.notStrictEqual(
+    state._seeded_stub,
+    true,
+    'real ROADMAP + missing state.json should NOT re-seed _seeded_stub — regression of #705',
+  );
+});
+
+test('#705 — re-install with stub ROADMAP + missing state.json DOES re-seed _seeded_stub', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+
+  runInstall(dir);
+
+  // Don't change ROADMAP (still has stub banner); just delete state.json.
+  fs.unlinkSync(path.join(dir, '.rihal', 'state.json'));
+
+  runInstall(dir);
+
+  const state = JSON.parse(fs.readFileSync(path.join(dir, '.rihal', 'state.json'), 'utf8'));
+  assert.strictEqual(
+    state._seeded_stub,
+    true,
+    'stub ROADMAP + missing state.json should re-seed _seeded_stub (true fresh-install case)',
+  );
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// #706 — brain-pull execFileSync must pass a timeout option.
+// Pre-fix, a slow upstream URL hung the entire install indefinitely.
+// We can't easily test the timeout firing without mocking, so verify the
+// option is wired by reading the source — guard against deletion.
+// ────────────────────────────────────────────────────────────────────────
+
+test('#706 — install.js brain-pull execFileSync includes a timeout option', () => {
+  const src = fs.readFileSync(INSTALL_JS, 'utf8');
+  // Find the brain pull call site.
+  const brainPullSection = src.match(
+    /execFileSync\([^,]+,\s*\[\s*toolsPath,\s*['"]brain['"],\s*['"]pull['"][\s\S]*?\}\)/,
+  );
+  assert.ok(brainPullSection, 'brain-pull execFileSync call not found in install.js');
+  assert.match(
+    brainPullSection[0],
+    /timeout:\s*\d+/,
+    'brain-pull execFileSync MUST pass a timeout option — regression of #706a',
+  );
+});

--- a/test/uninstall-units.test.cjs
+++ b/test/uninstall-units.test.cjs
@@ -123,6 +123,8 @@ function emptyPlan() {
     cursor:   [],
     windsurf: [],
     antigravity: [],
+    gemini:   [],
+    vscode:   [],
     agentsMd: false,
   };
 }
@@ -215,5 +217,62 @@ test('discoverKnownActionSkills returns the actions from the package manifest', 
   // (cli/lib/manifest.cjs:50 prefixes the bareId).
   for (const s of skills) {
     assert.ok(s.startsWith('rihal-'), `expected rihal- prefix on ${s}`);
+  }
+});
+
+// ---- #706b — gemini + vscode coverage in planToPathList ----
+
+test('#706 — planToPathList includes plan.gemini paths verbatim', () => {
+  const dir = makeTempDir();
+  try {
+    const plan = emptyPlan();
+    plan.gemini.push('.gemini/rihal/agents/rihal-waleed.md');
+    plan.gemini.push('.gemini/rihal/commands/rihal-status.md');
+
+    const paths = uninstall.planToPathList(plan, dir, { purge: false });
+
+    assert.ok(paths.includes('.gemini/rihal/agents/rihal-waleed.md'),
+      'gemini paths must be included (regression of #706b)');
+    assert.ok(paths.includes('.gemini/rihal/commands/rihal-status.md'),
+      'gemini paths must be included (regression of #706b)');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('#706 — planToPathList includes plan.vscode marker dir', () => {
+  const dir = makeTempDir();
+  try {
+    const plan = emptyPlan();
+    plan.vscode.push('.vscode/rihal');
+
+    const paths = uninstall.planToPathList(plan, dir, { purge: false });
+
+    assert.ok(paths.includes('.vscode/rihal'),
+      'vscode marker dir must be included (regression of #706b)');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('#706 — planToPathList does NOT crash when plan.gemini / plan.vscode absent (back-compat)', () => {
+  const dir = makeTempDir();
+  try {
+    // Old-shape plan without gemini/vscode keys (e.g. callers that haven't
+    // updated their plan factories).
+    const plan = {
+      claude:   { skills: [], commands: [], agents: [] },
+      cursor:   [],
+      windsurf: [],
+      antigravity: [],
+      agentsMd: false,
+    };
+
+    assert.doesNotThrow(
+      () => uninstall.planToPathList(plan, dir, { purge: false }),
+      'planToPathList must tolerate plans without gemini/vscode keys',
+    );
+  } finally {
+    cleanup(dir);
   }
 });

--- a/test/update-config-yaml.test.cjs
+++ b/test/update-config-yaml.test.cjs
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for #701 — `rcode update` was broken end-to-end on every
+ * real install because it read .rihal/config.json and JSON.parse'd it, but
+ * the installer writes .rihal/config.yaml.
+ *
+ * These tests pin three properties:
+ *   1. Update succeeds against a config.yaml-only install (the canonical
+ *      shape since v3.x).
+ *   2. The version key is written back as YAML, preserving every other
+ *      field including nested keys and comments.
+ *   3. detectInstalledEditors falls back to ~/.claude/skills/ when the
+ *      project skills dir is empty (post-#679 dedup) — without this fallback,
+ *      update reports "no editor install detected" on a normal install.
+ *
+ * Failure of any one of these tests means `rcode update` is broken on the
+ * dominant install layout. Treat as P0.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const INSTALL_JS = path.join(REPO_ROOT, 'cli', 'install.js');
+const { makeTempDir, cleanup } = require('./helpers.cjs');
+
+function gitInit(dir) {
+  spawnSync('git', ['init', '-q'], { cwd: dir });
+}
+
+function runInstall(target, extra = []) {
+  return spawnSync('node', [INSTALL_JS, '--target', target, '--no-update-check', '--yes', ...extra], {
+    encoding: 'utf8',
+  });
+}
+
+/**
+ * Run cli/update.js inline (so we don't need a published rcode bin).
+ * Mirrors how cli/index.js dispatches the command — passes packageRoot and
+ * packageJson so readPackageManifest works.
+ */
+async function runUpdate(cwd, packageVersion = '99.99.99', extra = []) {
+  const update = require('../cli/update.js');
+  const originalCwd = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await update(['--yes', ...extra], {
+      packageRoot: REPO_ROOT,
+      packageJson: { version: packageVersion },
+    });
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+test('#701 — update against a YAML config writes installed_version without crashing', async (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+
+  const r = runInstall(dir);
+  assert.strictEqual(r.status, 0, `install failed: ${r.stderr}`);
+
+  const configPath = path.join(dir, '.rihal', 'config.yaml');
+  assert.strictEqual(fs.existsSync(configPath), true, 'install must produce config.yaml');
+
+  // Initial config has no installed_version — update should add it.
+  const before = fs.readFileSync(configPath, 'utf8');
+  assert.doesNotMatch(before, /installed_version:/, 'fresh install should not have installed_version');
+
+  await runUpdate(dir, '99.99.99');
+
+  const after = fs.readFileSync(configPath, 'utf8');
+  assert.match(after, /installed_version:\s*"99\.99\.99"/, 'update must write installed_version');
+});
+
+test('#701 — update preserves YAML comments + nested keys + key ordering', async (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+  runInstall(dir);
+
+  const configPath = path.join(dir, '.rihal', 'config.yaml');
+  const before = fs.readFileSync(configPath, 'utf8');
+
+  // Sanity: install writes the comment header + nested workflow:/git: blocks
+  assert.match(before, /# Rihal v2 project config/);
+  assert.match(before, /workflow:/);
+  assert.match(before, /git:/);
+
+  await runUpdate(dir, '88.77.66');
+
+  const after = fs.readFileSync(configPath, 'utf8');
+  // Comment header preserved
+  assert.match(after, /# Rihal v2 project config/);
+  // Nested keys preserved (this used to be the foot-gun — JSON.parse would
+  // have thrown on these, then a JSON.stringify rewrite would have flattened them)
+  assert.match(after, /workflow:/);
+  assert.match(after, /  research_by_default:/);
+  assert.match(after, /git:/);
+  assert.match(after, /  branching_strategy:/);
+  // Top-level fields preserved
+  assert.match(after, /user_name:/);
+  assert.match(after, /project_name:/);
+  // The new key landed
+  assert.match(after, /installed_version:\s*"88\.77\.66"/);
+});
+
+test('#701 — update repeated bumps replace the existing installed_version exactly once', async (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  gitInit(dir);
+  runInstall(dir);
+
+  await runUpdate(dir, '1.0.0');
+  await runUpdate(dir, '2.0.0');
+  await runUpdate(dir, '3.0.0');
+
+  const after = fs.readFileSync(path.join(dir, '.rihal', 'config.yaml'), 'utf8');
+  // Exactly one installed_version line — the latest value.
+  const matches = after.match(/^installed_version:.*$/gm) || [];
+  assert.strictEqual(matches.length, 1, `expected 1 installed_version line, got ${matches.length}`);
+  assert.match(after, /installed_version:\s*"3\.0\.0"/);
+});
+
+test('#701 — detectInstalledEditors finds claude when project .claude/ is empty but globals exist', () => {
+  // The post-#679 dedup leaves .claude/skills/ empty when ~/.claude/skills/
+  // already has the rihal-* set. detectInstalledEditors must fall back.
+  const update = require('../cli/update.js');
+  const dir = makeTempDir();
+
+  try {
+    // Seed: empty project .claude/ + presence of .rihal/config.yaml.
+    fs.mkdirSync(path.join(dir, '.rihal'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.rihal', 'config.yaml'), 'user_name: "test"\n');
+
+    // Don't create any rihal-* files in project. Only globals exist.
+    const editors = update.detectInstalledEditors(dir);
+
+    // If the contributor's ~/.claude/skills/ has no rihal-* entries (CI),
+    // skip — we can't drive the fallback path from a tempdir alone. The
+    // explicit project-claude check (no fallback) is covered separately.
+    const os = require('os');
+    const homeSkills = path.join(os.homedir(), '.claude/skills');
+    const globalHasRihal = fs.existsSync(homeSkills) &&
+      fs.readdirSync(homeSkills).some(n => n.startsWith('rihal-'));
+
+    if (globalHasRihal) {
+      assert.ok(
+        editors.includes('claude'),
+        'with globals + .rihal/config.yaml, claude must be detected even if project .claude/ is empty',
+      );
+    } else {
+      // No globals → claude should NOT be detected (config alone isn't enough).
+      assert.ok(!editors.includes('claude'), 'no globals + no project files → claude should not be detected');
+    }
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('#701 — update on a project with neither config.yaml nor config.json exits with error', async (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+
+  // No install. Try update — should bail.
+  const update = require('../cli/update.js');
+  const originalCwd = process.cwd();
+  const originalExit = process.exit;
+  let exitCode = null;
+  process.exit = (code) => { exitCode = code; throw new Error(`__test_exit_${code}__`); };
+  process.chdir(dir);
+  try {
+    await update(['--yes'], { packageRoot: REPO_ROOT, packageJson: { version: '1.0.0' } });
+    assert.fail('update should have exited');
+  } catch (err) {
+    if (!String(err.message).startsWith('__test_exit_')) throw err;
+    assert.strictEqual(exitCode, 1, 'update should exit 1 when no config exists');
+  } finally {
+    process.exit = originalExit;
+    process.chdir(originalCwd);
+  }
+});


### PR DESCRIPTION
Closes #708.

## Summary

17 new regression tests pinning every fix from batch 5 (#701-#706). Each test names the issue it guards and emits a "regression of #N" marker in failure messages.

## Files

| File | Tests | Pins |
|---|---|---|
| \`test/update-config-yaml.test.cjs\` | 5 | #701 (rcode update broken end-to-end) |
| \`test/install-batch5-regressions.test.cjs\` | 9 | #702 manifest, #703 path-traversal, #705 stub guard, #706a brain timeout |
| \`test/uninstall-units.test.cjs\` (additions) | 3 | #706b vscode/gemini in planToPathList |

## Test totals

\`\`\`
Before: 242/242 passing
After:  259/259 passing
\`\`\`

Same pattern as the existing batch-3/batch-4 regression tests — spawn-based integration tests for end-to-end behavior, plus pure-function unit tests for hot paths. Every test stands alone (uses tempdirs from \`os.tmpdir()\` — never touches the contributor's filesystem outside the temp).

## What this prevents

A future refactor that, say, moves \`generateFilesManifest\` back above \`installSkills\` (regressing #702) gets a clear CI failure: \`"expected manifest to contain .rihal/skills/* entries, got 0. This means files-manifest.csv was generated before installSkills() ran — regression of #702."\`

Same pattern for every fix: the test failure tells you which ticket it pins.