### PR TITLE
feat(workflows): phase-id validator + milestone-health gauge (#718)

### DIFF
--- a/rihal/bin/rihal-tools.cjs
+++ b/rihal/bin/rihal-tools.cjs
@@ -29,13 +29,18 @@ const path = require('path');
 // When running from source (rihal/bin/), warn but allow — tests need this path.
 const _maybeRoot = path.resolve(__dirname, '..', '..');
 const _isInstalled = path.basename(path.dirname(__dirname)) === '.rihal';
-if (!_isInstalled && !process.env.RIHAL_DEV_MODE && !process.env.NODE_TEST_CONTEXT) {
+if (!_isInstalled && !process.env.RIHAL_DEV_MODE && !process.env.NODE_TEST_CONTEXT && !process.env.RIHAL_PROJECT_ROOT) {
   // Source dir, not installed location — warn but proceed (tests run from here)
   if (process.stderr.isTTY) {
     console.error('Note: rihal-tools.cjs running from source. For full features install with: node cli/install-v2.js <target> --yes');
   }
 }
-const PROJECT_ROOT = _maybeRoot;
+// Issue #718: RIHAL_PROJECT_ROOT env override lets tests (and future tooling)
+// retarget the binary at a different project root without symlinking. When
+// unset, behaves identically to before.
+const PROJECT_ROOT = process.env.RIHAL_PROJECT_ROOT
+  ? path.resolve(process.env.RIHAL_PROJECT_ROOT)
+  : _maybeRoot;
 const RIHAL_DIR = path.join(PROJECT_ROOT, '.rihal');
 const CONFIG_DIR = path.join(RIHAL_DIR, '_config');
 const REFS_DIR = path.join(RIHAL_DIR, 'references');
@@ -5371,6 +5376,119 @@ function cmdProjectStatus() {
   };
 }
 
+/**
+ * cmdValidatePhaseId — pure check that a phase ID conforms to rcode convention.
+ *
+ * Issue #718: workflows like `/rihal-plan` and `/rihal-audit` were producing
+ * freestyled IDs like "A1", "B5", "phase-x". Phase IDs must be integer
+ * (e.g. "19", "22") or decimal (e.g. "19.1", "22.3" — sub-phases under a
+ * parent integer). Anything else gets rejected loudly so the caller can fix
+ * the output before it pollutes ROADMAP.md.
+ */
+function cmdValidatePhaseId(id) {
+  if (id === undefined || id === null || id === '') {
+    return { ok: false, valid: false, error: 'no phase id provided' };
+  }
+  const str = String(id).trim();
+  // Strip leading zeros for the integer pattern check (per feedback memory:
+  // no leading zeros — phase 6 not 06). The integer pattern below already
+  // forbids them but we want a clear error when the caller passes "06".
+  if (/^0\d/.test(str)) {
+    return { ok: false, valid: false, id: str, error: `leading zeros not allowed — use ${str.replace(/^0+/, '')}` };
+  }
+  // Accepted shape: <int>(.<int>)? — e.g. "19", "19.1", "22.3"
+  const ok = /^([1-9]\d*)(\.[1-9]\d*)?$/.test(str);
+  if (!ok) {
+    return {
+      ok: false,
+      valid: false,
+      id: str,
+      error: `phase id "${str}" does not match integer or decimal pattern (e.g. 19, 19.1, 22)`,
+    };
+  }
+  return { ok: true, valid: true, id: str, kind: str.includes('.') ? 'decimal' : 'integer' };
+}
+
+/**
+ * cmdValidateRoadmap — scan .planning/ROADMAP.md for phase headings whose
+ * IDs don't conform. Returns the list of offenders with line numbers so
+ * the caller can flag them. Read-only — never modifies ROADMAP.
+ */
+function cmdValidateRoadmap() {
+  const roadmapPath = path.join(PROJECT_ROOT, '.planning', 'ROADMAP.md');
+  if (!fs.existsSync(roadmapPath)) {
+    return { ok: true, valid: true, offenders: [], note: 'no ROADMAP.md' };
+  }
+  let text;
+  try { text = fs.readFileSync(roadmapPath, 'utf8'); }
+  catch (e) { return { ok: false, error: `read failed: ${e.message}` }; }
+
+  const offenders = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Match phase headings: "## Phase <id>" anywhere, also "### Phase <id>"
+    const m = line.match(/^#{2,3}\s+Phase\s+([^\s—:–]+)/i);
+    if (!m) continue;
+    const id = m[1].trim();
+    const r = cmdValidatePhaseId(id);
+    if (!r.valid) {
+      offenders.push({ line: i + 1, id, reason: r.error });
+    }
+  }
+  return {
+    ok: true,
+    valid: offenders.length === 0,
+    offenders,
+    scanned: lines.length,
+    roadmap: '.planning/ROADMAP.md',
+  };
+}
+
+/**
+ * cmdMilestoneHealth — gauge for the current milestone (issue #718).
+ *
+ * Counts open vs done phases under the current milestone and recommends
+ * action when the milestone is getting unwieldy. Workflows like
+ * /rihal-add-phase and /rihal-status read this to nudge users toward
+ * /rihal-complete-milestone before the phase list balloons.
+ *
+ * Thresholds (kept conservative — bump in config later if needed):
+ *   - "consider closing" when >= 8 open phases under one milestone
+ *   - "should close" when >= 12 open phases (hard nudge)
+ */
+function cmdMilestoneHealth() {
+  const statePath = path.join(RIHAL_DIR, 'state.json');
+  if (!fs.existsSync(statePath)) return { ok: true, milestone: null, note: 'no state.json' };
+  let state;
+  try { state = JSON.parse(fs.readFileSync(statePath, 'utf8')); }
+  catch (e) { return { ok: false, error: `invalid state.json: ${e.message}` }; }
+
+  const milestone = state.milestone || null;
+  const phases = Array.isArray(state.phases) ? state.phases : [];
+  // "Open" = not done. State schema uses status: 'planned' | 'in_progress' |
+  // 'completed' | 'verified' | 'shipped'. Treat anything not in
+  // {completed, verified, shipped} as open.
+  const doneStatuses = new Set(['completed', 'verified', 'shipped']);
+  const open = phases.filter(p => !doneStatuses.has(p.status));
+  const done = phases.filter(p => doneStatuses.has(p.status));
+
+  let recommendation = 'healthy';
+  if (open.length >= 12) recommendation = 'should-close';
+  else if (open.length >= 8) recommendation = 'consider-closing';
+
+  return {
+    ok: true,
+    milestone,
+    phase_count: phases.length,
+    open_phases: open.length,
+    completed_phases: done.length,
+    recommendation,
+    threshold_consider: 8,
+    threshold_should: 12,
+  };
+}
+
 function cmdStateSnapshot() {
   const statePath = path.join(RIHAL_DIR, 'state.json');
   if (!fs.existsSync(statePath)) return { ok: true, state: null };
@@ -5747,6 +5865,15 @@ async function main() {
         break;
       case 'project-status':
         result = cmdProjectStatus();
+        break;
+      case 'validate-phase-id':
+        result = cmdValidatePhaseId(args[0]);
+        break;
+      case 'validate-roadmap':
+        result = cmdValidateRoadmap();
+        break;
+      case 'milestone-health':
+        result = cmdMilestoneHealth();
         break;
       case 'version':
         console.log(readPackageVersion());

--- a/rihal/references/phase-id-conventions.md
+++ b/rihal/references/phase-id-conventions.md
@@ -1,0 +1,101 @@
+# Phase ID Conventions
+
+The canonical rule for naming a phase in rcode. Issue #718.
+
+---
+
+## TL;DR
+
+| Shape | Example | Use case |
+|-------|---------|----------|
+| `<int>` | `19`, `22`, `103` | Top-level phase added at the end of the current milestone |
+| `<int>.<int>` | `19.1`, `19.2`, `22.3` | Sub-phase inserted under an existing parent |
+| anything else | `A1`, `B5`, `phase-x`, `06` | **REJECTED** |
+
+Validate any ID with:
+
+```bash
+node .rihal/bin/rihal-tools.cjs validate-phase-id <id>
+```
+
+Scan an entire ROADMAP at once:
+
+```bash
+node .rihal/bin/rihal-tools.cjs validate-roadmap
+```
+
+---
+
+## Why these are the only two shapes
+
+**Integer phases (`19`, `22`)** are the natural unit of milestone progress.
+They're added to the end of the roadmap by `/rihal-add-phase` and the
+`phase add` CLI calculates the next number automatically. This is the
+default — 99% of phases should be integers.
+
+**Decimal sub-phases (`19.1`, `19.2`)** exist for one purpose: inserting
+focused work under an already-defined parent without renumbering everything
+after it. Use `/rihal-phase insert 19.1` (the `phase` subcommand) — the
+parent phase stays `19`, the sub-phase fits between `19` and `20` without
+shifting `20→21→22…`.
+
+**Anything else is freestyling.** Audit-style outputs that produce `A1`,
+`B5`, "Audit Phase 1", or domain-prefixed names (`auth-1`, `sec-2`) break:
+
+- ROADMAP.md parsing — the `## Phase <id>` regex assumes a number
+- State.json schema — `phases[].id` is typed as a number-or-decimal string
+- Dashboard rendering — sorts phases by numeric value
+- Cross-phase references in SUMMARY.md, PLAN.md, etc.
+
+If you find yourself wanting `A1` or `B1`, you actually want **two
+milestones**: one for audit, one for implementation. Run
+`/rihal-complete-milestone` on the audit milestone before the
+implementation work starts.
+
+---
+
+## Leading zeros: never
+
+Per feedback memory: `19`, not `019`. `6`, not `06`. The validator
+rejects leading-zero forms explicitly because they cause downstream
+sorting bugs and inconsistent file naming (`.planning/phases/06-foo`
+vs `.planning/phases/6-foo`).
+
+---
+
+## Where the validator fires
+
+- **`/rihal-add-phase`** — runs `milestone-health` after adding, nudges
+  toward `/rihal-complete-milestone` when ≥8 phases are open.
+- **`/rihal-status`** — surfaces milestone-health gauge when not `healthy`.
+- **CI** (`test/scope-history-parity.test.cjs` style) — a future test
+  can call `validate-roadmap` against the committed ROADMAP.md.
+
+Workflows that produce phase IDs from AI freestyle (`/rihal-plan`,
+`/rihal-audit-milestone`) MUST call `validate-phase-id` before writing
+to disk. If they don't, file an issue.
+
+---
+
+## Milestone health thresholds
+
+| Open phases | Recommendation | Behavior |
+|-------------|----------------|----------|
+| 0–7 | `healthy` | Quiet — no nudge |
+| 8–11 | `consider-closing` | Soft nudge after `/rihal-add-phase` |
+| ≥12 | `should-close` | Hard nudge with both close + fork commands |
+
+Bump thresholds in a future PR if real-world data shows users want bigger
+milestones. Current numbers are conservative on purpose — long milestones
+without closure are the original symptom.
+
+---
+
+## Related
+
+- `rihal/workflows/add-phase.md` — milestone-health check after adding
+- `rihal/workflows/status.md` — milestone-health gauge in status output
+- `rihal/workflows/complete-milestone.md` — the closure workflow
+- `rihal/bin/rihal-tools.cjs` — `validate-phase-id`, `validate-roadmap`,
+  `milestone-health` subcommands
+- Issue #718 (this file's origin)

--- a/rihal/workflows/add-phase.md
+++ b/rihal/workflows/add-phase.md
@@ -104,6 +104,43 @@ Update STATE.md to reflect the new phase:
 If "Roadmap Evolution" section doesn't exist, create it.
 </step>
 
+<step name="milestone_health_check">
+After the phase is added, run the milestone-health gauge (issue #718):
+
+```bash
+HEALTH=$(node ".rihal/bin/rihal-tools.cjs" milestone-health 2>/dev/null)
+RECOMMENDATION=$(echo "$HEALTH" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).recommendation||'unknown')}catch{console.log('unknown')}})")
+OPEN_COUNT=$(echo "$HEALTH" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).open_phases||0)}catch{console.log(0)}})")
+MILESTONE_NAME=$(echo "$HEALTH" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).milestone||'')}catch{console.log('')}})")
+```
+
+If `RECOMMENDATION` is `should-close` (≥12 open phases), surface a hard nudge:
+
+```
+⚠ Milestone health: {MILESTONE_NAME} has {OPEN_COUNT} open phases.
+
+Phase {N} is now in this milestone, but the milestone is well past the
+12-phase threshold for considering closure. Phases are accumulating without
+a milestone boundary — historically this is where roadmaps lose structure.
+
+Recommended next step:
+  /rihal-complete-milestone    close {MILESTONE_NAME} cleanly + archive done phases
+  /rihal-new-milestone         start a fresh milestone for ongoing work
+
+If you genuinely want a giant single-milestone roadmap, ignore this and
+continue. The threshold is conservative on purpose.
+```
+
+If `RECOMMENDATION` is `consider-closing` (8-11 open phases), softer nudge:
+
+```
+ℹ Milestone health: {MILESTONE_NAME} has {OPEN_COUNT} open phases — getting full.
+   Consider /rihal-complete-milestone before adding more.
+```
+
+If `RECOMMENDATION` is `healthy`, say nothing.
+</step>
+
 <step name="completion">
 Present completion summary:
 

--- a/rihal/workflows/status.md
+++ b/rihal/workflows/status.md
@@ -53,6 +53,25 @@ Then stop.
 If `SNAPSHOT.weighted_progress > 0` but `SNAPSHOT.completed_count === 0`, display
 the weighted bar as the primary progress indicator to avoid a misleading `0/N (0%)`.
 
+### Milestone health (issue #718)
+
+After the main dashboard, call `rihal-tools milestone-health` and surface
+a gauge when the milestone is full:
+
+```bash
+HEALTH=$(node ".rihal/bin/rihal-tools.cjs" milestone-health 2>/dev/null)
+```
+
+Parse `recommendation`, `open_phases`, `phase_count`. Display ONLY when
+`recommendation` is not `healthy`:
+
+```
+⚠ Milestone health: {open_phases} open / {phase_count} total — {recommendation}
+   → /rihal-complete-milestone to close, or /rihal-new-milestone to fork
+```
+
+When healthy, print nothing — keeps status terse for normal projects.
+
 ## Step 3 — Phases section
 
 For each entry in `SNAPSHOT.phases[]`:

--- a/test/milestone-discipline.test.cjs
+++ b/test/milestone-discipline.test.cjs
@@ -1,0 +1,215 @@
+/**
+ * Tests for the milestone-discipline subcommands (issue #718 / Wave 7).
+ *
+ * Pins three rihal-tools subcommands:
+ *   - validate-phase-id: pure check on a single ID
+ *   - validate-roadmap:  scan ROADMAP.md for offenders
+ *   - milestone-health:  open vs done phase count + recommendation
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TOOLS = path.join(REPO_ROOT, 'rihal', 'bin', 'rihal-tools.cjs');
+const { makeTempDir, cleanup } = require('./helpers.cjs');
+
+function run(args, opts = {}) {
+  // When opts.cwd is set, ALSO point RIHAL_PROJECT_ROOT at it so the tool
+  // reads from the tempdir instead of the rcode repo it loaded from.
+  // Without this, PROJECT_ROOT stays at the script's location (rihal-tools
+  // resolves __dirname/../..) and validate-roadmap / milestone-health read
+  // the wrong files. See #718.
+  const env = { ...process.env, NODE_DISABLE_COLORS: '1' };
+  if (opts.cwd) env.RIHAL_PROJECT_ROOT = opts.cwd;
+  const r = spawnSync('node', [TOOLS, ...args], {
+    encoding: 'utf8',
+    cwd: opts.cwd || REPO_ROOT,
+    env,
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); } catch { /* leave null */ }
+  return { ...r, json };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// validate-phase-id
+// ────────────────────────────────────────────────────────────────────────
+
+test('validate-phase-id: accepts integer phase ids', () => {
+  for (const id of ['1', '19', '22', '103', '9999']) {
+    const r = run(['validate-phase-id', id]);
+    assert.strictEqual(r.json && r.json.valid, true, `expected ${id} valid`);
+    assert.strictEqual(r.json.kind, 'integer');
+  }
+});
+
+test('validate-phase-id: accepts decimal sub-phase ids', () => {
+  for (const id of ['19.1', '22.3', '1.1', '103.99']) {
+    const r = run(['validate-phase-id', id]);
+    assert.strictEqual(r.json && r.json.valid, true, `expected ${id} valid`);
+    assert.strictEqual(r.json.kind, 'decimal');
+  }
+});
+
+test('validate-phase-id: rejects letter-prefix shapes (A1, B5, etc.)', () => {
+  for (const id of ['A1', 'B5', 'a1', 'audit-1', 'phase-x']) {
+    const r = run(['validate-phase-id', id]);
+    assert.strictEqual(r.json && r.json.valid, false, `expected ${id} rejected`);
+    assert.match(r.json.error, /does not match integer or decimal/);
+  }
+});
+
+test('validate-phase-id: rejects leading zeros with a clear hint', () => {
+  const r = run(['validate-phase-id', '06']);
+  assert.strictEqual(r.json && r.json.valid, false);
+  assert.match(r.json.error, /leading zeros not allowed.*use 6/);
+});
+
+test('validate-phase-id: rejects empty / missing input', () => {
+  const r = run(['validate-phase-id', '']);
+  assert.strictEqual(r.json && r.json.valid, false);
+});
+
+test('validate-phase-id: rejects negative numbers and floats with leading dot', () => {
+  for (const id of ['-1', '.5', '1.', '1.0.0']) {
+    const r = run(['validate-phase-id', id]);
+    assert.strictEqual(r.json && r.json.valid, false, `expected ${id} rejected`);
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// validate-roadmap
+// ────────────────────────────────────────────────────────────────────────
+
+test('validate-roadmap: returns valid=true on a fresh project with no roadmap', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  const r = run(['validate-roadmap'], { cwd: dir });
+  assert.strictEqual(r.json && r.json.valid, true);
+});
+
+test('validate-roadmap: catches A1/B5-style offenders', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.planning', 'ROADMAP.md'),
+    [
+      '# Roadmap',
+      '',
+      '## Phase 19 — real',
+      '',
+      '## Phase A1 — freestyled',
+      '',
+      '## Phase B5 — also freestyled',
+      '',
+      '## Phase 22.3 — sub-phase',
+      '',
+      '## Phase 06 — leading zero',
+      '',
+    ].join('\n'),
+  );
+
+  const r = run(['validate-roadmap'], { cwd: dir });
+  assert.strictEqual(r.json.valid, false);
+  assert.strictEqual(r.json.offenders.length, 3);
+
+  const ids = r.json.offenders.map(o => o.id);
+  assert.ok(ids.includes('A1'));
+  assert.ok(ids.includes('B5'));
+  assert.ok(ids.includes('06'));
+  assert.ok(!ids.includes('19'));
+  assert.ok(!ids.includes('22.3'));
+});
+
+test('validate-roadmap: reports line numbers so callers can fix in place', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.planning', 'ROADMAP.md'),
+    '# Roadmap\n\n## Phase 19\n\n## Phase A1\n',
+  );
+  const r = run(['validate-roadmap'], { cwd: dir });
+  const offender = r.json.offenders.find(o => o.id === 'A1');
+  assert.ok(offender);
+  assert.strictEqual(offender.line, 5);
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// milestone-health
+// ────────────────────────────────────────────────────────────────────────
+
+function writeState(dir, state) {
+  fs.mkdirSync(path.join(dir, '.rihal'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.rihal', 'state.json'), JSON.stringify(state));
+}
+
+test('milestone-health: healthy when ≤7 open phases', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  writeState(dir, {
+    milestone: 'M1',
+    phases: [
+      { id: '1', status: 'completed' },
+      { id: '2', status: 'completed' },
+      { id: '3', status: 'in_progress' },
+      { id: '4', status: 'planned' },
+    ],
+  });
+  const r = run(['milestone-health'], { cwd: dir });
+  assert.strictEqual(r.json.recommendation, 'healthy');
+  assert.strictEqual(r.json.open_phases, 2);
+  assert.strictEqual(r.json.completed_phases, 2);
+});
+
+test('milestone-health: consider-closing when 8-11 open phases', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  const phases = [];
+  for (let i = 1; i <= 9; i++) phases.push({ id: String(i), status: 'planned' });
+  writeState(dir, { milestone: 'M1', phases });
+  const r = run(['milestone-health'], { cwd: dir });
+  assert.strictEqual(r.json.recommendation, 'consider-closing');
+});
+
+test('milestone-health: should-close when ≥12 open phases', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  const phases = [];
+  for (let i = 1; i <= 15; i++) phases.push({ id: String(i), status: 'planned' });
+  writeState(dir, { milestone: 'M1', phases });
+  const r = run(['milestone-health'], { cwd: dir });
+  assert.strictEqual(r.json.recommendation, 'should-close');
+  assert.strictEqual(r.json.open_phases, 15);
+});
+
+test('milestone-health: treats verified + shipped as done (not open)', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  writeState(dir, {
+    milestone: 'M1',
+    phases: [
+      { id: '1', status: 'completed' },
+      { id: '2', status: 'verified' },
+      { id: '3', status: 'shipped' },
+      { id: '4', status: 'planned' },
+    ],
+  });
+  const r = run(['milestone-health'], { cwd: dir });
+  assert.strictEqual(r.json.completed_phases, 3);
+  assert.strictEqual(r.json.open_phases, 1);
+  assert.strictEqual(r.json.recommendation, 'healthy');
+});
+
+test('milestone-health: returns gracefully when no state.json', (t) => {
+  const dir = makeTempDir();
+  t.after(() => cleanup(dir));
+  const r = run(['milestone-health'], { cwd: dir });
+  assert.strictEqual(r.json.ok, true);
+  assert.strictEqual(r.json.milestone, null);
+});


### PR DESCRIPTION
Closes #718.

## Summary

Two gaps surfaced by an audit that produced \`A1-A7\` / \`B1-B5\` phase IDs:

1. **Phase IDs unenforced.** \`/rihal-plan\` and \`/rihal-audit-milestone\` freestyle. rcode's actual convention (integer or decimal-subphase) was undocumented + unvalidated.
2. **Milestone closure never prompted.** \`/rihal-add-phase\` happily appends phase #25 under M1 with no nudge. rcode's own state.json is at 25 open phases under a single milestone — the bug is dogfooded.

## What ships

### 3 new \`rihal-tools\` subcommands

- \`validate-phase-id <id>\` — pure check. Accepts \`19\`, \`19.1\`. Rejects \`A1\`, \`06\`, \`-1\`, \`1.\`, \`1.0.0\`, \`phase-x\`.
- \`validate-roadmap\` — scans \`.planning/ROADMAP.md\` for non-conforming phase headings; reports offenders with line numbers.
- \`milestone-health\` — counts open vs done phases. Returns \`healthy\` / \`consider-closing\` (8-11) / \`should-close\` (≥12).

### Workflow wiring

- \`add-phase.md\` — after phase added, runs \`milestone-health\` and shows a hard nudge toward \`/rihal-complete-milestone\` at \`should-close\`, soft nudge at \`consider-closing\`, silent at \`healthy\`.
- \`status.md\` — same gauge, terse one-line when not healthy. Quiet for normal projects.

### Documentation

\`rihal/references/phase-id-conventions.md\` pins the rule with examples + validator commands.

### Testability

\`PROJECT_ROOT\` now honors \`RIHAL_PROJECT_ROOT\` env override (defaults to existing behavior). Tests retarget without symlinking.

## Verification

- 14 new tests in \`test/milestone-discipline.test.cjs\`.
- Full suite: **273/273 passing**.
- Running \`validate-roadmap\` on rcode's own ROADMAP catches historical \`01\`, \`02\` leading-zero offenders (existing data flagged correctly; clean separately).
- \`milestone-health\` on rcode's state: \`should-close\` (25 open under M1) — the gauge is firing on the very repo that needs it.