### PR TITLE
fix(skills): code-review step-02 dispatches to actual agents not skills (closes #720)

### DIFF
--- a/rihal/skills/actions/4-implementation/rihal-code-review/steps/step-02-review.md
+++ b/rihal/skills/actions/4-implementation/rihal-code-review/steps/step-02-review.md
@@ -17,11 +17,15 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 2. Launch parallel subagents without conversation context. If subagents are not available, generate prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, resume from this point and proceed to step 3.
 
-   - **Blind Hunter** — receives `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `rihal-review-adversarial-general` skill.
+   **Subagent mapping** (issue #720): the three reviewer roles below map to actual agents shipped in `.claude/agents/`. The skill names that used to be referenced here (`rihal-review-adversarial-general`, `rihal-review-edge-case-hunter`) are skills, not subagents, and `Task(subagent_type=...)` cannot reach them. Use the agents listed.
 
-   - **Edge Case Hunter** — receives `{diff_output}` and read access to the project. Invoke via the `rihal-review-edge-case-hunter` skill.
+   - **Blind Hunter** — receives `{diff_output}` only. No spec, no context docs, no project access. Dispatch:
+     `Task(subagent_type="rihal-security-adversary", model="sonnet", prompt="<adversarial review of diff>")`. The security-adversary persona's cynical mindset is the right fit for an isolated diff-only review.
 
-   - **Acceptance Auditor** (only if `{review_mode}` = `"full"`) — receives `{diff_output}`, the content of the file at `{spec_file}`, and any loaded context docs. Its prompt:
+   - **Edge Case Hunter** — receives `{diff_output}` and read access to the project. Dispatch:
+     `Task(subagent_type="rihal-edge-case-hunter", model="sonnet", prompt="<enumerate edge cases for diff>")`.
+
+   - **Acceptance Auditor** (only if `{review_mode}` = `"full"`) — receives `{diff_output}`, the content of the file at `{spec_file}`, and any loaded context docs. Dispatch via `rihal-code-reviewer`. Its prompt:
      > You are an Acceptance Auditor. Review this diff against the spec and context docs. Check for: violations of acceptance criteria, deviations from spec intent, missing implementation of specified behavior, contradictions between spec constraints and actual code. Output findings as a Markdown list. Each finding: one-line title, which AC/constraint it violates, and evidence from the diff.
 
 3. **Subagent failure handling**: If any subagent fails, times out, or returns empty results, append the layer name to `{failed_layers}` (comma-separated) and proceed with findings from the remaining layers.


### PR DESCRIPTION
## Symptom

`/rihal-code-review` errors with `Agent type 'rihal-review-adversarial-general' not found` and never runs the parallel review.

## Root cause

`step-02-review.md` line 20 said "Invoke via the `rihal-review-adversarial-general` skill". The name exists as a **skill** in `rihal/skills/core/`, not as an agent. The surrounding "Launch parallel subagents" wording made the AI dispatch `Task(subagent_type=rihal-review-adversarial-general)` which fails.

## Fix

Three reviewer roles now dispatch to actual agents in `rihal/agents/`:

- **Blind Hunter** → `rihal-security-adversary` (adversarial, no context)
- **Edge Case Hunter** → `rihal-edge-case-hunter` (exact role match)
- **Acceptance Auditor** → `rihal-code-reviewer`

Wording also changed from ambiguous "Invoke via the X skill" to explicit `Task(subagent_type=...)` so future readers can't mis-dispatch.

The sibling `review-edge-case-hunter.md` and `review-adversarial.md` workflows already dispatched correctly — only this one site was broken.

## Verification

- `rihal/agents/` confirmed to contain all three referenced agents.
- 273/273 tests passing.
- Zero remaining "Invoke via the X skill" patterns in the codebase.