### PR TITLE
fix(ci): use pnpm in release workflow instead of npm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Setup Node 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: pnpm
 
+      # This repo uses pnpm (pnpm-lock.yaml, lockfileVersion 9.0); `npm ci`
+      # fails with EUSAGE because there is no package-lock.json.
       - name: Install build dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build CLI bundle (dist/rcode.js)
-        run: npm run build:cli
+        run: pnpm run build:cli
 
       - name: Verify bundle is self-contained
         run: |


### PR DESCRIPTION
Closes #885

## Problem

The `release` workflow runs `npm ci`, but this repo uses **pnpm** (`pnpm-lock.yaml`, lockfileVersion 9.0) and has no `package-lock.json`. So every tag push failed at the install step with `EUSAGE: npm ci can only install with an existing package-lock.json` — and **no GitHub Release was ever created** (v3.6.1, v4.0.0, v4.1.2 runs all failed in ~12s). The v4.1.2 release had to be created manually with `gh release create`.

## Fix

- Add `pnpm/action-setup@v4` (version 10, matching the dev environment)
- Enable `cache: pnpm` on `setup-node`
- Switch install/build steps: `npm ci` → `pnpm install --frozen-lockfile`, `npm run build:cli` → `pnpm run build:cli`

## Verification

Both previously-failing steps pass locally on this lockfile:
- `pnpm install --frozen-lockfile` → exit 0 (lockfile in sync)
- `pnpm run build:cli` → valid `dist/rcode.js`, reports `4.1.2`, parses + runs

End-to-end CI only runs on a tag push, so the full workflow is confirmed on the next release tag.

## Out of scope

`test` and `dogfood` checks currently fail on `main` too, for unrelated reasons — not caused by this change and not fixable here (this PR only touches `release.yml`).