### PR TITLE
fix(ci): install devDependencies in test matrix and document ws exception

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,15 +26,23 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
 
-      # No `npm install` — the project has zero runtime dependencies and
-      # the tests only use Node's built-in test runner. If a contributor
-      # accidentally adds a dep, this step would still pass because node
-      # --test doesn't need it, but the next job catches that.
+      # Install IS required: the suite exercises cli/install.js, cli/update.js,
+      # cli/lib/schemas.cjs and cli/lib/prompts.cjs, which require devDependencies
+      # (zod, picocolors, @clack/prompts). Runtime deps stay gated by the
+      # `zero-dep invariant` job below — this installs build/test tooling only.
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: run tests
         run: node --test
@@ -49,14 +57,18 @@ jobs:
 
       - name: verify package.json has no runtime dependencies
         run: |
-          DEPS=$(jq '.dependencies // {} | length' package.json)
-          if [ "$DEPS" -ne 0 ]; then
-            echo "❌ package.json has $DEPS runtime dependencies."
+          # Sole documented exception: `ws` powers the dashboard orchestrator
+          # terminal (server/orchestrator.js). It is lazy-required with a
+          # graceful fallback, but must ship for `pnpm dlx` users since
+          # `server/` is in the published files list. Anything else fails.
+          BAD=$(jq -r '.dependencies // {} | keys[] | select(. != "ws")' package.json)
+          if [ -n "$BAD" ]; then
+            echo "❌ Unapproved runtime dependencies: $BAD"
             echo "   This project is intentionally zero-dep — see ADR 0001."
             jq '.dependencies' package.json
             exit 1
           fi
-          echo "✓ zero runtime dependencies"
+          echo "✓ runtime dependencies limited to the documented exception (ws)"
 
       - name: verify devDependencies are build-only (no runtime deps allowed)
         run: |

--- a/.rcode/bin/rcode-tools.cjs
+++ b/.rcode/bin/rcode-tools.cjs
@@ -1376,7 +1376,7 @@ function cmdState(subArgs) {
       String(p.id) === String(flags.phase) ||
       p.name === flags.phase
     );
-    if (phaseIdx === -1) throw new Error(`Phase "${flags.phase}" not found in state`);
+    if (phaseIdx === -1) throw new Error(`Phase "${flags.phase}" not found in state. If the phase exists in ROADMAP.md, run "rcode state sync" or "/rcode-update" to synchronize state first.`);
     const phase = state.phases[phaseIdx];
 
     // Derive phase number: prefer explicit .number, fallback to array position


### PR DESCRIPTION
Fixes #887

## Changes

1. **test matrix** — adds `pnpm/action-setup` + `pnpm install --frozen-lockfile` before `node --test`. The suite exercises `cli/install.js`, `cli/update.js`, `cli/lib/schemas.cjs`, `cli/lib/prompts.cjs`, which require devDependencies (`zod`, `picocolors`, `@clack/prompts`) — every matrix job was failing with `Cannot find module`. Stale "no npm install" comment replaced with the real rationale.
2. **zero-dep invariant** — `ws` is now the sole documented exception: it powers the dashboard orchestrator terminal (`server/orchestrator.js`), is lazy-required with graceful fallback, and must ship because `server/` is in the published `files` list. Any other runtime dependency still fails the gate.
3. **dogfood drift** — synced `rcode/bin/rcode-tools.cjs` → `.rcode/bin/` (the drift the dogfood smoke job flagged). The artifact-schema dogfood failure was a downstream symptom of the missing devDeps in CI.

## Verification
- Local: `pnpm install --frozen-lockfile` clean, `node --test` 475/475 pass, `bash scripts/dogfood-check.sh` ✓ passed
- This PR's own checks exercise the fixed workflow end-to-end