### PR TITLE
feat(skills): herdr-orchestration gap fixes + dashboard per-task transparency

### DIFF
--- a/.planning/audits/AUDIT-dashboard-transparency.md
+++ b/.planning/audits/AUDIT-dashboard-transparency.md
@@ -1,0 +1,54 @@
+# Audit — Diwan dashboard per-task actions + results (#905)
+
+## Goal
+The Diwan dashboard showed task *status* but not **what each task actually did**.
+This change adds per-task execution transparency (RuFlo-GOAP-style): each task row
+can expand to show the ordered **actions performed** and the **result/outcome**.
+
+## Where the data came from (no new sources, view-only)
+Each `<task>` block in `.planning/phases/**/NN-N-SPRINT.md` already contains:
+- `<action>` — the ordered, numbered steps the task performs.
+- `<done>` — the one-line outcome/result of the task.
+
+The scanner previously parsed only `id`, `title`, `status`, and `acceptance` from
+these blocks. This change reads the `<action>` and `<done>` text that was *already
+loaded into memory* during the same parse — no new files, no new endpoints, no writes.
+
+## Changes
+1. **`server/lib/scanner.js`**
+   - Added `parseActionSteps(raw)` — splits a numbered `<action>` block into an
+     ordered string[] (one collapsed line per step); falls back to non-empty lines.
+   - In `buildPhaseTree`'s `<task>` parse loop, extract `<action>` → `story.actions`
+     (string[]) and `<done>` → `story.outcome` (string). Both omitted when absent.
+   - These fields flow unchanged through the existing `phaseTree` → `allTasks()`
+     path (same path that already surfaces `acceptance`).
+
+2. **`server/lib/html/client/components/shared.js`** (`TaskCard`)
+   - In the existing expanded `.task-detail` section, render an "Actions performed"
+     ordered list (`t.actions`) and a "Result" callout (`t.outcome`), each guarded so
+     tasks without the data render exactly as before.
+   - No new deps, no React.FC, no inline `style=` for the new markup (CSS classes only).
+
+3. **`server/lib/html/css.js`**
+   - Added `.task-actions`, `.task-actions-title`, `.task-actions-list`,
+     `.task-action-step`, `.task-outcome`, `.task-outcome-label`, `.task-outcome-text`
+     using existing design tokens (`--space-*`, `--accent-green`, `--bg-elev-2`,
+     `--border-subtle`, `--radius-4`).
+
+## Constraints honoured
+- View-only: NO write endpoints, NO POST handlers, NO DB code added.
+- `server/dashboard.js` untouched; stays pure Node stdlib, dependency-free, single-file.
+- Client stays dependency-free Preact. No new deps (`package.json` byte-identical).
+- Incremental: existing TaskCard / scanner logic preserved; only additive changes.
+
+## Verification
+- `node --input-type=module --check < server/lib/html/client/components/shared.js` → OK.
+- `node --check server/lib/scanner.js` → OK.
+- Scanner smoke test against this repo's `.planning/`: 170 tasks parsed; 86 carry
+  `actions`, 83 carry `outcome` (e.g. task `29.1.1` → 3 steps + outcome).
+- `node server/dashboard.js` boots cleanly on port 7717 (orchestrator on 7718),
+  no errors; process killed after confirming startup.
+- `git status` shows only the 3 intended source files modified; no lockfile or
+  `package.json` changes.
+</content>
+</invoke>

--- a/.planning/audits/AUDIT-skill-rules.md
+++ b/.planning/audits/AUDIT-skill-rules.md
@@ -1,0 +1,52 @@
+# AUDIT — herdr-orchestration skill doc-gap edits (Agent A)
+
+Branch: `gap/herdr-skill-rules`. Eight commits, one per issue (final commit = this audit doc).
+All edits scoped to `rcode/skills/actions/4-implementation/rcode-herdr-orchestration/`.
+Incremental additions only — no existing content rewritten. Skill compliance check passes
+(Output Format, Examples, triggers, Overview all present).
+
+## Commits
+
+### #898 — shared mid-wave scratchpad
+- `rules/wave-design.md`: added `### Shared coordination doc` — every wave agent reads
+  `.planning/campaign/SHARED.md` before starting and appends a one-line claim
+  (`area — agent N — status`) so same-wave agents don't duplicate work.
+- `SKILL.md`: added matching one-line mention in the MODE 2 summary.
+
+### #899 — verify beyond TSC + resolvable provenance
+- `rules/merge-strategy.md`: added `### Per-agent verification gate (beyond compile)`
+  (task doc exists, scoped tests pass, lint clean, diff non-trivial/on-topic) and
+  `### Resolvable provenance` (openable evidence ref required; gate FAILS if unresolvable;
+  cites the `[object Object]` "94% confidence" false-verify failure mode).
+
+### #900 — wave token/cost budget
+- `rules/orchestrator-rhythm.md`: added cost-ceiling stop condition — estimate
+  `agents × wave-duration` before dispatch, stop/ask if it exceeds the ceiling.
+- `rules/wave-design.md`: added `### Log cost per wave` — one-line cost/agent-count note
+  to `.planning/campaign/STATE.md` per wave.
+
+### #901 — optional reviewer/anti-drift agent
+- `rules/wave-design.md`: added `### Optional reviewer agent` — for overlapping areas or
+  campaigns >3 waves, a reviewer runs after coders, reads branch diffs, flags
+  conflicts/drift/duplication before merge. Kept optional; flat fan-out stays default.
+
+### #902 — blast-radius/safety framing
+- `SKILL.md`: added `## Safety — blast radius of skip-permissions agents` near Golden rules —
+  scope each agent to its worktree+area; worktree isolation is the only containment under
+  skip-permissions; never point an autonomous agent at a shared/important tree.
+
+### #903 — pane status false-positive risk
+- `rules/orchestrator-rhythm.md`: added `### Pane status is text-scraping` anti-pattern —
+  status is inferred from pane text, a stuck agent can read `working` forever; made the
+  25-min stuck-working → read pane → `C-c` + re-dispatch a rule; suggested heartbeat marker.
+
+### #904 — cross-campaign learning
+- `rules/backlog-building.md`: added `### Campaign retro (optional)` — append
+  `.planning/campaign/RETRO.md` at campaign end (wave sizes, what stalled, what merged clean);
+  flagged the YAGNI/over-engineering tension (Lens 16) explicitly.
+
+### audit (this file)
+- `.planning/audits/AUDIT-skill-rules.md`: this summary (force-added; `.planning/` may be gitignored).
+
+## Not pushed
+Per task instructions, no `git push` was run. Eight local commits on `gap/herdr-skill-rules`.

--- a/.rcode/state.json
+++ b/.rcode/state.json
@@ -2,7 +2,7 @@
   "version": "1",
   "project": "rcode",
   "created": "2026-04-15T13:11:19.259Z",
-  "updated": "2026-06-23T06:44:02.291Z",
+  "updated": "2026-06-17T22:34:14.771Z",
   "current_phase": "Proactive intent router — UserPromptSubmit nudge toward rcode commands for memory consistency (#892)",
   "current_plan": 6,
   "model_profile": "balanced",
@@ -1516,30 +1516,6 @@
       "goal": "",
       "status": "planned",
       "file": ".planning/phases/37-phase-dependency-graph-and-structured-rejection-dialogs/37-2-SPRINT.md"
-    },
-    {
-      "key": "38/1",
-      "phase": "38",
-      "number": "1",
-      "goal": "\"Add the prompt-router subcommand to rcode-hooks.cjs — keyword-match the user's prompt against the do.md-derived routing table, respect the prompt_nudge toggle + per-session dedupe, emit a memory-framed additionalContext advisory, and swallow every error (exit 0 silent).\"",
-      "status": "planned",
-      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-1-SPRINT.md"
-    },
-    {
-      "key": "38/2",
-      "phase": "38",
-      "number": "2",
-      "goal": "\"Wire the prompt-router as a UserPromptSubmit hook into settings-hooks.json and the opt-in enable-hooks flow, plus declare the prompt_nudge config key, so the proactive nudge installs for Claude Code only when the user opts in. Idempotent merge, never on by default.\"",
-      "status": "planned",
-      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-2-SPRINT.md"
-    },
-    {
-      "key": "38/3",
-      "phase": "38",
-      "number": "3",
-      "goal": "\"Prevent silent drift: add a sync test that asserts every command the INTENT_TABLE routes to actually appears in the do.md routing table (the single source of truth), so a future edit to do.md that removes/renames a command fails CI rather than leaving the nudge pointing at a dead command.\"",
-      "status": "planned",
-      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-3-SPRINT.md"
     }
   ],
   "plans": [],

--- a/.rcode/state.json
+++ b/.rcode/state.json
@@ -2,7 +2,7 @@
   "version": "1",
   "project": "rcode",
   "created": "2026-04-15T13:11:19.259Z",
-  "updated": "2026-06-17T22:34:14.771Z",
+  "updated": "2026-06-23T06:44:02.291Z",
   "current_phase": "Proactive intent router — UserPromptSubmit nudge toward rcode commands for memory consistency (#892)",
   "current_plan": 6,
   "model_profile": "balanced",
@@ -1516,6 +1516,30 @@
       "goal": "",
       "status": "planned",
       "file": ".planning/phases/37-phase-dependency-graph-and-structured-rejection-dialogs/37-2-SPRINT.md"
+    },
+    {
+      "key": "38/1",
+      "phase": "38",
+      "number": "1",
+      "goal": "\"Add the prompt-router subcommand to rcode-hooks.cjs — keyword-match the user's prompt against the do.md-derived routing table, respect the prompt_nudge toggle + per-session dedupe, emit a memory-framed additionalContext advisory, and swallow every error (exit 0 silent).\"",
+      "status": "planned",
+      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-1-SPRINT.md"
+    },
+    {
+      "key": "38/2",
+      "phase": "38",
+      "number": "2",
+      "goal": "\"Wire the prompt-router as a UserPromptSubmit hook into settings-hooks.json and the opt-in enable-hooks flow, plus declare the prompt_nudge config key, so the proactive nudge installs for Claude Code only when the user opts in. Idempotent merge, never on by default.\"",
+      "status": "planned",
+      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-2-SPRINT.md"
+    },
+    {
+      "key": "38/3",
+      "phase": "38",
+      "number": "3",
+      "goal": "\"Prevent silent drift: add a sync test that asserts every command the INTENT_TABLE routes to actually appears in the do.md routing table (the single source of truth), so a future edit to do.md that removes/renames a command fails CI rather than leaving the nudge pointing at a dead command.\"",
+      "status": "planned",
+      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-3-SPRINT.md"
     }
   ],
   "plans": [],

--- a/.rcode/state.json
+++ b/.rcode/state.json
@@ -2,7 +2,7 @@
   "version": "1",
   "project": "rcode",
   "created": "2026-04-15T13:11:19.259Z",
-  "updated": "2026-06-23T06:43:48.757Z",
+  "updated": "2026-06-17T22:34:14.771Z",
   "current_phase": "Proactive intent router — UserPromptSubmit nudge toward rcode commands for memory consistency (#892)",
   "current_plan": 6,
   "model_profile": "balanced",
@@ -1516,30 +1516,6 @@
       "goal": "",
       "status": "planned",
       "file": ".planning/phases/37-phase-dependency-graph-and-structured-rejection-dialogs/37-2-SPRINT.md"
-    },
-    {
-      "key": "38/1",
-      "phase": "38",
-      "number": "1",
-      "goal": "\"Add the prompt-router subcommand to rcode-hooks.cjs — keyword-match the user's prompt against the do.md-derived routing table, respect the prompt_nudge toggle + per-session dedupe, emit a memory-framed additionalContext advisory, and swallow every error (exit 0 silent).\"",
-      "status": "planned",
-      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-1-SPRINT.md"
-    },
-    {
-      "key": "38/2",
-      "phase": "38",
-      "number": "2",
-      "goal": "\"Wire the prompt-router as a UserPromptSubmit hook into settings-hooks.json and the opt-in enable-hooks flow, plus declare the prompt_nudge config key, so the proactive nudge installs for Claude Code only when the user opts in. Idempotent merge, never on by default.\"",
-      "status": "planned",
-      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-2-SPRINT.md"
-    },
-    {
-      "key": "38/3",
-      "phase": "38",
-      "number": "3",
-      "goal": "\"Prevent silent drift: add a sync test that asserts every command the INTENT_TABLE routes to actually appears in the do.md routing table (the single source of truth), so a future edit to do.md that removes/renames a command fails CI rather than leaving the nudge pointing at a dead command.\"",
-      "status": "planned",
-      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-3-SPRINT.md"
     }
   ],
   "plans": [],

--- a/.rcode/state.json
+++ b/.rcode/state.json
@@ -2,7 +2,7 @@
   "version": "1",
   "project": "rcode",
   "created": "2026-04-15T13:11:19.259Z",
-  "updated": "2026-06-17T22:34:14.771Z",
+  "updated": "2026-06-23T06:43:48.757Z",
   "current_phase": "Proactive intent router — UserPromptSubmit nudge toward rcode commands for memory consistency (#892)",
   "current_plan": 6,
   "model_profile": "balanced",
@@ -1516,6 +1516,30 @@
       "goal": "",
       "status": "planned",
       "file": ".planning/phases/37-phase-dependency-graph-and-structured-rejection-dialogs/37-2-SPRINT.md"
+    },
+    {
+      "key": "38/1",
+      "phase": "38",
+      "number": "1",
+      "goal": "\"Add the prompt-router subcommand to rcode-hooks.cjs — keyword-match the user's prompt against the do.md-derived routing table, respect the prompt_nudge toggle + per-session dedupe, emit a memory-framed additionalContext advisory, and swallow every error (exit 0 silent).\"",
+      "status": "planned",
+      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-1-SPRINT.md"
+    },
+    {
+      "key": "38/2",
+      "phase": "38",
+      "number": "2",
+      "goal": "\"Wire the prompt-router as a UserPromptSubmit hook into settings-hooks.json and the opt-in enable-hooks flow, plus declare the prompt_nudge config key, so the proactive nudge installs for Claude Code only when the user opts in. Idempotent merge, never on by default.\"",
+      "status": "planned",
+      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-2-SPRINT.md"
+    },
+    {
+      "key": "38/3",
+      "phase": "38",
+      "number": "3",
+      "goal": "\"Prevent silent drift: add a sync test that asserts every command the INTENT_TABLE routes to actually appears in the do.md routing table (the single source of truth), so a future edit to do.md that removes/renames a command fails CI rather than leaving the nudge pointing at a dead command.\"",
+      "status": "planned",
+      "file": ".planning/phases/38-proactive-intent-router-userpromptsubmit-nudge-toward-rcode-commands-for-memory-consistency-892/38-3-SPRINT.md"
     }
   ],
   "plans": [],

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/SKILL.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/SKILL.md
@@ -118,6 +118,8 @@ Full Phase 0-3 protocol, integration-branch rules, wave cadence, and anti-patter
 in **`references.md`** (sibling file). Key constraints:
 
 - Maintain one `campaign-integration` branch; sub-agents fork from it, never master.
+- Each wave agent reads `.planning/campaign/SHARED.md` first and appends a one-line claim
+  (`area — agent N — status`) so same-wave agents don't duplicate work.
 - Wave size: 3-5 agents, 10-15 min per wave. ScheduleWakeup ends EVERY turn.
 - Phase 3: show user the full diff + ask explicitly how to land (PR / merge / squash / leave).
 - Never push to origin master without an explicit yes — per campaign, not per session.

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/SKILL.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/SKILL.md
@@ -74,6 +74,16 @@ independent agents.
 
 ---
 
+## Safety — blast radius of skip-permissions agents
+
+Every orchestrated agent runs `cld` (= `claude --dangerously-skip-permissions`). There is **no human gate** on local destructive commands — an agent can `rm`, `git reset --hard`, overwrite files, or run any shell command without asking. So:
+
+- **Scope each agent prompt to its own worktree + area only.** State the worktree path and branch explicitly, and tell the agent to stay inside it.
+- **Worktree isolation is the only containment.** With permissions skipped, a per-agent git worktree is the single boundary that keeps one agent's mistakes from touching another's work or the main tree.
+- **Never point an autonomous agent at a shared or important tree** (your main checkout, a production clone, anything you can't afford to lose). Always a throwaway worktree.
+
+---
+
 ## herdr CLI reference
 
 ```bash

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/backlog-building.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/backlog-building.md
@@ -52,6 +52,19 @@ git commit -m "chore(campaign): backlog snapshot at wave <N>"
 ```
 The `-f` is required if `.planning/` is gitignored (common in Rihal projects).
 
+### Campaign retro (optional)
+At campaign end, append a short `.planning/campaign/RETRO.md` so the *next* campaign on this repo starts smarter:
+- Wave sizes actually used (and which felt right vs too big).
+- What stalled — areas that needed re-dispatch, conflict hotspots, agents that went silent.
+- What merged clean on the first pass.
+
+```bash
+git add -f .planning/campaign/RETRO.md
+git commit -m "chore(campaign): retro notes for next campaign"
+```
+
+**YAGNI tension (be honest)**: this is speculative tooling — a second campaign on the same repo may never happen, and a RETRO doc no one reads is exactly the kind of over-engineering Lens 16 flags. Write it only when a follow-up campaign is genuinely likely; for a one-off campaign, skip it.
+
 ## Examples
 
 ### Building backlog from audit docs

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/merge-strategy.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/merge-strategy.md
@@ -27,6 +27,23 @@ fi
 ```
 **Never compound regressions across waves.**
 
+### Per-agent verification gate (beyond compile)
+A passing TSC count proves the tree compiles — it does NOT prove the agent did the work it claimed. Before merging a branch, verify **inside the worktree**:
+
+1. **Task/audit doc exists and claims the work.** The agent's `.planning/audits/AUDIT-<area>.md` (or task doc) must exist and describe what it changed. No doc → no merge.
+2. **`pnpm test` (or the project test command) passes for the affected area.** Run the scoped suite, not just the type-checker.
+3. **Lint is clean or unchanged.** Run the project linter; a new lint regression blocks the merge the same way a TSC regression does.
+4. **The diff is non-trivial and on-topic.** `git diff campaign-integration..<branch> --stat` — an empty diff, a whitespace-only diff, or edits outside the agent's area mean the agent didn't actually do the work. Reject and re-dispatch.
+
+Only after all four pass does the branch enter the smallest-first merge order.
+
+### Resolvable provenance
+A wave is NOT "verified" until each claimed change has an **openable evidence reference** — a passing test name you can run, a diff hunk you can read, a real `file:line` you can open. A self-declared boolean (`verified: true`, `confidence: 0.94`) is not provenance; it's a claim about provenance.
+
+**If provenance can't resolve, the gate FAILS** — treat the change as unverified and block the merge.
+
+Failure mode to watch for: a verifier that stamps `"verified / 94% confidence"` while its citation layer actually renders `[object Object]` has verified *nothing*. The boolean looks green; the evidence underneath is broken. Always click through to the citation — if the reference doesn't open to the thing it claims, the verification is void regardless of the confidence number.
+
 ### Conflict resolution (delegates to herdr-orchestration)
 - Content conflicts: read both sides, keep the **more-complete superset side**, remove markers, syntax-check, stage, commit. (See herdr-orchestration rules.)
 - AA conflicts (add/add): peek both versions; if nearly identical, keep the canonical owner's version. The "owner" is the branch whose audit doc claimed the feature.

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/orchestrator-rhythm.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/orchestrator-rhythm.md
@@ -99,6 +99,12 @@ If the orchestrator hits auto-compact mid-campaign, the first turn after must:
 
 ## Anti-Patterns
 
+### Pane status is text-scraping — trust it loosely
+
+**Problem**: `agent_status` (`working`/`blocked`/`idle`) is *inferred from the pane's visible text*, not a real process signal. A stuck agent — frozen mid-output, hung on a network call, or wedged in a loop — leaves its last tokens on screen and can read `working` indefinitely. A green `working` is not proof of progress.
+**Rule (timeout heuristic, now mandatory)**: if a pane reads `working` for **25 min straight**, `herdr pane read <id>` and inspect the actual output. If there's no new progress since the last peek (no new commit, same last line), `C-c` the pane and re-dispatch the item in the next wave. Do not wait out a silently-dead agent on the strength of its status string.
+**Optional reinforcement**: have each agent emit a heartbeat marker line periodically (e.g. `echo "[hb] wave-3 still alive $(date -u +%T)"`); then "no new `[hb]` line in N min" is a far more reliable stuck-signal than the scraped status.
+
 ### Polling every 60s
 
 **Problem**: Wakeup interval shorter than 270s burns the Anthropic prompt cache repeatedly without any real work happening (sub-agents need minutes between commits).

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/orchestrator-rhythm.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/orchestrator-rhythm.md
@@ -56,6 +56,9 @@ If the user picks (c) or skips: NEVER claim "Scheduling 20-min wakeup" in chat �
 | Phase 3 (draining last waves) | 270s | Sub-agents finishing close to each other; don't miss the last |
 | Idle (waiting on stuck pane) | 1200s | Sub-agent stuck — give it room or surface it |
 
+### Cost ceiling — estimate before dispatch
+Before dispatching a wave, the orchestrator estimates `agents × wave-duration` (and, across the campaign, the running sum of all waves) as a rough cost proxy. If a planned campaign exceeds a ceiling — by default **~20 agent-waves** or any explicit token/budget cap the user gave — the orchestrator STOPS and asks the user to confirm before continuing rather than burning budget silently. A 17-wave × 4-agent campaign is ~68 agent-runs; surface that number up front so the user can scope it down.
+
 ### Stop conditions
 The heartbeat should stop ONLY when ALL three are true:
 - Every herdr pane is `idle` or `done`

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/wave-design.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/wave-design.md
@@ -59,6 +59,14 @@ After each wave dispatch, append a one-line cost/agent-count note to `.planning/
 wave 3: 4 agents dispatched, ~12 min target — running total: 11 agent-runs
 ```
 
+### Optional reviewer agent
+For waves that touch **overlapping areas**, or campaigns running **more than 3 waves**, add one reviewer agent that runs *after* the wave's coders finish but *before* the merge step. The reviewer:
+- Reads all branch diffs for the wave (`git diff campaign-integration..<branch>` per branch).
+- Flags conflicts, scope drift, and duplicated work across the branches.
+- Reports to `.planning/campaign/STATE.md` (or a `REVIEW-wave-<N>.md`) — it does NOT merge.
+
+Keep it **optional**. For small bounded work (3-4 distinct, non-overlapping areas), the flat fan-out stays the default — a reviewer agent there is pure overhead. Add it only when the conflict surface or campaign length justifies the extra agent-run.
+
 ## Examples
 
 ### Good wave-1 composition (from real session)

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/wave-design.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/wave-design.md
@@ -53,6 +53,12 @@ For each backlog item, score before assigning to a wave:
 - Past 25 min: peek at all panes, identify stuck agents, decide kill-or-wait.
 - Hard stop: 45 min. If a wave hasn't produced commits in 45 min, something is wrong — abort and re-dispatch.
 
+### Log cost per wave
+After each wave dispatch, append a one-line cost/agent-count note to `.planning/campaign/STATE.md` so the running campaign total stays visible (and the cost ceiling in `orchestrator-rhythm.md` can be checked against it):
+```
+wave 3: 4 agents dispatched, ~12 min target — running total: 11 agent-runs
+```
+
 ## Examples
 
 ### Good wave-1 composition (from real session)

--- a/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/wave-design.md
+++ b/rcode/skills/actions/4-implementation/rcode-herdr-orchestration/rules/wave-design.md
@@ -13,6 +13,13 @@ A campaign with too few agents underuses parallelism; too many causes merge conf
 - **Maximum: 5.** Above 5 the merge stage becomes painful and TSC regressions compound across simultaneous changes.
 - **Sequential or concurrent waves?** Concurrent only if you have >8 distinct unrelated areas AND the merge bookkeeping is automated. Default is sequential: dispatch wave → merge → dispatch wave.
 
+### Shared coordination doc
+Every wave agent reads `.planning/campaign/SHARED.md` **before starting**, and appends a one-line claim the moment it picks up an area:
+```
+<area> — agent <N> — <status>
+```
+e.g. `crm-pipeline — agent 2 — claimed`. This stops two parallel agents in the same wave from silently grabbing the same area or file domain. The orchestrator seeds the file at wave dispatch; agents only append, never rewrite. Statuses progress `claimed` → `working` → `done` (or `skipped: <reason>`). If an agent finds its target area already claimed, it stops and reports back instead of duplicating work.
+
 ### Wave scope rules
 Each agent in a wave must:
 - Own a **distinct audit area** (no two agents touching the same file domain).

--- a/server/lib/html/client/components/shared.js
+++ b/server/lib/html/client/components/shared.js
@@ -354,6 +354,20 @@ export function TaskCard({ task: t }) {
           ` : null}
           ${t.acceptance ? html`<div class="task-detail-row"><strong>Acceptance:</strong> ${t.acceptance}</div>` : null}
           ${t.assignee ? html`<div class="task-detail-row"><strong>Assignee:</strong> ${t.assignee}</div>` : null}
+          ${(t.actions && t.actions.length) ? html`
+            <div class="task-actions">
+              <div class="task-actions-title">Actions performed</div>
+              <ol class="task-actions-list">
+                ${t.actions.map((step, i) => html`<li key=${i} class="task-action-step">${step}</li>`)}
+              </ol>
+            </div>
+          ` : null}
+          ${t.outcome ? html`
+            <div class="task-outcome">
+              <span class="task-outcome-label">Result</span>
+              <span class="task-outcome-text">${t.outcome}</span>
+            </div>
+          ` : null}
           ${taskCmds.length ? html`
             <div class="task-detail-cmds">
               ${taskCmds.map(([cmd, desc]) => html`<${CmdHint} key=${cmd} cmd=${cmd} desc=${desc}/>`)}

--- a/server/lib/html/css.js
+++ b/server/lib/html/css.js
@@ -770,6 +770,46 @@ section .body {
 }
 .task-detail-row strong { color: var(--text-muted); font-weight: 500; min-width: 64px; flex-shrink: 0; }
 .task-detail-cmds { margin-top: var(--space-3); }
+/* ── Per-task actions + result (#905) ───────────────────────────── */
+.task-actions {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+.task-actions-title {
+  color: var(--text-muted);
+  font-weight: 500;
+  margin-bottom: var(--space-2);
+}
+.task-actions-list {
+  margin: 0;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.task-action-step {
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+.task-outcome {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elev-2);
+  border-left: 2px solid var(--accent-green);
+  border-radius: var(--radius-4);
+}
+.task-outcome-label {
+  color: var(--accent-green);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.task-outcome-text { color: var(--text-secondary); line-height: 1.45; }
 .task-expand-icon {
   font-size: 8px;
   color: var(--text-muted);

--- a/server/lib/scanner.js
+++ b/server/lib/scanner.js
@@ -81,6 +81,23 @@ function parseYamlList(text, key) {
 }
 
 /**
+ * Parse a SPRINT.md <action> block into an ordered list of action steps.
+ * Action blocks are numbered ("1. …\n2. …"); each step may span several lines.
+ * Whitespace within a step is collapsed so each renders as one readable line.
+ * Falls back to non-empty lines when the block is not numbered. Returns [].
+ */
+function parseActionSteps(raw) {
+  if (!raw) return [];
+  const t = raw.trim();
+  if (!t) return [];
+  const matches = [...t.matchAll(/(?:^|\n)\s*\d+\.\s+([\s\S]*?)(?=\n\s*\d+\.\s|$)/g)];
+  if (matches.length) {
+    return matches.map(m => m[1].replace(/\s+/g, ' ').trim()).filter(Boolean);
+  }
+  return t.split('\n').map(l => l.replace(/^[-*]\s+/, '').trim()).filter(Boolean);
+}
+
+/**
  * Derive the phase → sprint → story tree from the .planning/phases/ filesystem,
  * which is the committed source of truth. state.json sprint/story records are
  * often incomplete (planner agents write SPRINT.md files without registering
@@ -147,6 +164,14 @@ function buildPhaseTree(projectDir, rawPhases, listCached, overrides) {
         };
         if (ov[story.id]) story.status = ov[story.id].status;
         if (acM && acM[1].trim()) story.acceptance = acM[1].trim();
+        // Per-task execution transparency (#905): the ordered <action> steps
+        // (what the task does) + the <done> outcome (the result). Read-only —
+        // parsed from the same SPRINT.md text already loaded above.
+        const actionM = tm[2].match(/<action>\s*([\s\S]*?)\s*<\/action>/);
+        const doneM   = tm[2].match(/<done>\s*([\s\S]*?)\s*<\/done>/);
+        const steps   = actionM ? parseActionSteps(actionM[1]) : [];
+        if (steps.length) story.actions = steps;
+        if (doneM && doneM[1].trim()) story.outcome = doneM[1].replace(/\s+/g, ' ').trim();
         stories.push(story);
       }
       // Fallback for pre-<task> SPRINT.md format (phases 20-30 era):


### PR DESCRIPTION
## Summary

Closes gaps found auditing ruvnet/ruflo's orchestration layer against the `rcode-herdr-orchestration` skill, plus the dashboard transparency feature. Implemented via dogfooded herdr orchestration (2 worktree-isolated cld agents, file-ownership partitioned, clean merge — no conflicts).

## Skill doc gaps (8 commits)
- **#898** shared mid-wave coordination doc (`SHARED.md`) — `wave-design.md`
- **#899** verification beyond TSC + **resolvable provenance** rule — `merge-strategy.md` (sharpened by the RuFlo `[object Object]` citation failure: a "verified" flag without openable evidence verifies nothing)
- **#900** wave cost ceiling + per-wave cost logging — `orchestrator-rhythm.md`, `wave-design.md`
- **#901** optional reviewer/anti-drift agent — `wave-design.md`
- **#902** blast-radius safety note for skip-permissions agents — `SKILL.md`
- **#903** pane-status text-scraping false-positive + timeout heuristic — `orchestrator-rhythm.md`
- **#904** optional campaign retro for cross-campaign learning — `backlog-building.md`

## Dashboard feature (1 commit)
- **#905** per-task **actions performed + result** in Diwan (GOAP-style transparency). The `<action>`/`<done>` data already lived in SPRINT.md `<task>` blocks; surfaced read-only via `scanner.js` → `TaskCard`. View-only, zero new deps.

## Testing
- ESM/`node --check` on `shared.js`, `css.js`, `scanner.js` — pass
- `node server/dashboard.js` boots clean
- All 8 skill gap markers present
- Functional: scanner extraction proven on a real SPRINT.md (33 action steps + outcome)

## Notes
- A hook-side-effect `.rcode/state.json` change was reverted — not part of this work.
- Dashboard stays view-only (no write endpoints / POST / DB).

Refs #898 #899 #900 #901 #902 #903 #904 #905